### PR TITLE
Add the Clone trait to language_tags::Error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ fn is_alphanumeric_or_dash(s: &str) -> bool {
 /// Defines an Error type for langtags.
 ///
 /// Errors occur mainly during parsing of language tags.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Error {
     /// The same extension subtag is only allowed once in a tag before the private use part.
     DuplicateExtension,


### PR DESCRIPTION
I'm working on a project that uses `language_tags`, and it would be helpful if the error type was cloneable. (I have my own error enum that can contain `language_tags::Error`, and I'd like that type to be cloneable.)
