### PR TITLE
Use heapsize_derive instead of heapsize_plugin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ travis-ci = { repository = "pyfisch/rust-language-tags" }
 version = ">=0.2.2, <0.4"
 optional = true
 
-[dependencies.heapsize_plugin]
-version = "0.1.2"
+[dependencies.heapsize_derive]
+version = "0.1.4"
 optional = true
 
 [features]
-heap_size = ["heapsize", "heapsize_plugin"]
+heap_size = ["heapsize", "heapsize_derive"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 #![deny(missing_docs)]
 #![cfg_attr(test, deny(warnings))]
-#![cfg_attr(feature = "heap_size", feature(custom_derive, plugin))]
-#![cfg_attr(feature = "heap_size", plugin(heapsize_plugin))]
 
 //! Language tags can be used identify human languages, scripts e.g. Latin script, countries and
 //! other regions.
@@ -51,8 +49,10 @@
 
 #[cfg(feature = "heap_size")]
 extern crate heapsize;
+#[cfg(feature = "heap_size")]
+#[macro_use]
+extern crate heapsize_derive;
 
-use std::ascii::AsciiExt;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error as ErrorTrait;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 extern crate language_tags;
 
-use std::ascii::AsciiExt;
 use std::default::Default;
 use std::collections::BTreeMap;
 


### PR DESCRIPTION
The `heapsize_plugin` crate is no longer working with current `rustc`, and `heapsize_derive` seems to be the direct successor.
I stumbled upon the compile error with the `heap_size` feature enabled while attempting to package `rust-language-tags` for Debian as a dependency for other crate packages. Once the fix is merged and a new version is released, the package can be included in Debian without maintaining an external patch.