### PR TITLE
Rewrite LanguageTag to do only one string allocation on parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,7 @@ in Belgium and print it:
 
 ```rust
 use language_tags::LanguageTag;
-let mut langtag: LanguageTag = Default::default();
-langtag.language = Some("fr".to_owned());
-langtag.region = Some("BE".to_owned());
+let langtag = LanguageTag::parse("fr-BE").unwrap();
 assert_eq!(format!("{}", langtag), "fr-BE");
 ```
 
@@ -31,9 +29,10 @@ Parse a tag representing a special type of English specified by private agreemen
 
 ```rust
 use language_tags::LanguageTag;
+use std::iter::FromIterator;
 let langtag: LanguageTag = "en-x-twain".parse().unwrap();
-assert_eq!(format!("{}", langtag.language.unwrap()), "en");
-assert_eq!(format!("{:?}", langtag.privateuse), "[\"twain\"]");
+assert_eq!(langtag.primary_language(), "en");
+assert_eq!(Vec::from_iter(langtag.private_use_subtags()), vec!["twain"]);
 ```
 
 You can check for equality, but more often you should test if two tags match.
@@ -45,12 +44,9 @@ in `de` the request should be rejected.
 
 ```rust
 use language_tags::LanguageTag;
-let mut langtag1: LanguageTag = Default::default();
-langtag1.language = Some("de".to_owned());
-langtag1.region = Some("AT".to_owned());
-let mut langtag2: LanguageTag = Default::default();
-langtag2.language = Some("de".to_owned());
-assert!(langtag2.matches(&langtag1));
+let mut langtag_server = LanguageTag::parse("de-AT").unwrap();
+let mut langtag_user = LanguageTag::parse("de").unwrap();
+assert!(langtag_user.matches(&langtag_server));
 ```
 
 There is also the `langtag!` macro for creating language tags.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,9 +20,7 @@
 //!
 //! ```rust
 //! use language_tags::LanguageTag;
-//! let mut langtag: LanguageTag = Default::default();
-//! langtag.language = Some("fr".to_owned());
-//! langtag.region = Some("BE".to_owned());
+//! let langtag = LanguageTag::parse("fr-BE").unwrap();
 //! assert_eq!(format!("{}", langtag), "fr-BE");
 //! ```
 //!
@@ -30,20 +28,18 @@
 //!
 //! ```rust
 //! use language_tags::LanguageTag;
+//! use std::iter::FromIterator;
 //! let langtag: LanguageTag = "en-x-twain".parse().unwrap();
-//! assert_eq!(format!("{}", langtag.language.unwrap()), "en");
-//! assert_eq!(format!("{:?}", langtag.privateuse), "[\"twain\"]");
+//! assert_eq!(langtag.primary_language(), "en");
+//! assert_eq!(Vec::from_iter(langtag.private_use_subtags()), vec!["twain"]);
 //! ```
 //!
 //! You can check for equality, but more often you should test if two tags match.
 //!
 //! ```rust
 //! use language_tags::LanguageTag;
-//! let mut langtag_server: LanguageTag = Default::default();
-//! langtag_server.language = Some("de".to_owned());
-//! langtag_server.region = Some("AT".to_owned());
-//! let mut langtag_user: LanguageTag = Default::default();
-//! langtag_user.language = Some("de".to_owned());
+//! let mut langtag_server = LanguageTag::parse("de-AT").unwrap();
+//! let mut langtag_user = LanguageTag::parse("de").unwrap();
 //! assert!(langtag_user.matches(&langtag_server));
 //! ```
 //!
@@ -52,259 +48,352 @@
 #[cfg(feature = "heap_size")]
 extern crate heapsize;
 
-use std::ascii::AsciiExt;
-use std::cmp::Ordering;
-use std::collections::{BTreeMap, BTreeSet};
-use std::error::Error as ErrorTrait;
-use std::fmt::{self, Display};
-use std::iter::FromIterator;
-
-fn is_alphabetic(s: &str) -> bool {
-    s.chars().all(|x| x >= 'A' && x <= 'Z' || x >= 'a' && x <= 'z')
-}
-
-fn is_numeric(s: &str) -> bool {
-    s.chars().all(|x| x >= '0' && x <= '9')
-}
-
-fn is_alphanumeric_or_dash(s: &str) -> bool {
-    s.chars()
-     .all(|x| x >= 'A' && x <= 'Z' || x >= 'a' && x <= 'z' || x >= '0' && x <= '9' || x == '-')
-}
-
-/// Defines an Error type for langtags.
-///
-/// Errors occur mainly during parsing of language tags.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum Error {
-    /// The same extension subtag is only allowed once in a tag before the private use part.
-    DuplicateExtension,
-    /// If an extension subtag is present, it must not be empty.
-    EmptyExtension,
-    /// If the `x` subtag is present, it must not be empty.
-    EmptyPrivateUse,
-    /// The langtag contains a char that is not A-Z, a-z, 0-9 or the dash.
-    ForbiddenChar,
-    /// A subtag fails to parse, it does not match any other subtags.
-    InvalidSubtag,
-    /// The given language subtag is invalid.
-    InvalidLanguage,
-    /// A subtag may be eight characters in length at maximum.
-    SubtagTooLong,
-    /// At maximum three extlangs are allowed, but zero to one extlangs are preferred.
-    TooManyExtlangs,
-}
-
-impl ErrorTrait for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::DuplicateExtension => "The same extension subtag is only allowed once in a tag",
-            Error::EmptyExtension => "If an extension subtag is present, it must not be empty",
-            Error::EmptyPrivateUse => "If the `x` subtag is present, it must not be empty",
-            Error::ForbiddenChar => "The langtag contains a char not allowed",
-            Error::InvalidSubtag => "A subtag fails to parse, it does not match any other subtags",
-            Error::InvalidLanguage => "The given language subtag is invalid",
-            Error::SubtagTooLong => "A subtag may be eight characters in length at maximum",
-            Error::TooManyExtlangs => "At maximum three extlangs are allowed",
-        }
-    }
-}
-
-impl Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(self.description())
-    }
-}
-
-/// Result type used for this library.
-pub type Result<T> = ::std::result::Result<T, Error>;
+use std::error::Error;
+use std::fmt;
+use std::iter::once;
+use std::str::Split;
 
 /// Contains all grandfathered tags.
-pub const GRANDFATHERED: [(&'static str, Option<&'static str>); 26] = [("art-lojban", Some("jbo")),
-                                                                       ("cel-gaulish", None),
-                                                                       ("en-GB-oed",
-                                                                        Some("en-GB-oxendict")),
-                                                                       ("i-ami", Some("ami")),
-                                                                       ("i-bnn", Some("bnn")),
-                                                                       ("i-default", None),
-                                                                       ("i-enochian", None),
-                                                                       ("i-hak", Some("hak")),
-                                                                       ("i-klingon", Some("tlh")),
-                                                                       ("i-lux", Some("lb")),
-                                                                       ("i-mingo", None),
-                                                                       ("i-navajo", Some("nv")),
-                                                                       ("i-pwn", Some("pwn")),
-                                                                       ("i-tao", Some("tao")),
-                                                                       ("i-tay", Some("tay")),
-                                                                       ("i-tsu", Some("tsu")),
-                                                                       ("no-bok", Some("nb")),
-                                                                       ("no-nyn", Some("nn")),
-                                                                       ("sgn-BE-FR", Some("sfb")),
-                                                                       ("sgn-BE-NL", Some("vgt")),
-                                                                       ("sgn-CH-DE", Some("sgg")),
-                                                                       ("zh-guoyu", Some("cmn")),
-                                                                       ("zh-hakka", Some("hak")),
-                                                                       ("zh-min", None),
-                                                                       ("zh-min-nan", Some("nan")),
-                                                                       ("zh-xiang", Some("hsn"))];
+pub const GRANDFATHERED: [(&str, Option<&str>); 26] = [
+    ("art-lojban", Some("jbo")),
+    ("cel-gaulish", None),
+    ("en-GB-oed", Some("en-GB-oxendict")),
+    ("i-ami", Some("ami")),
+    ("i-bnn", Some("bnn")),
+    ("i-default", None),
+    ("i-enochian", None),
+    ("i-hak", Some("hak")),
+    ("i-klingon", Some("tlh")),
+    ("i-lux", Some("lb")),
+    ("i-mingo", None),
+    ("i-navajo", Some("nv")),
+    ("i-pwn", Some("pwn")),
+    ("i-tao", Some("tao")),
+    ("i-tay", Some("tay")),
+    ("i-tsu", Some("tsu")),
+    ("no-bok", Some("nb")),
+    ("no-nyn", Some("nn")),
+    ("sgn-BE-FR", Some("sfb")),
+    ("sgn-BE-NL", Some("vgt")),
+    ("sgn-CH-DE", Some("sgg")),
+    ("zh-guoyu", Some("cmn")),
+    ("zh-hakka", Some("hak")),
+    ("zh-min", None),
+    ("zh-min-nan", Some("nan")),
+    ("zh-xiang", Some("hsn")),
+];
 
-const DEPRECATED_LANGUAGE: [(&'static str, &'static str); 53] = [("in", "id"),
-                                                                 ("iw", "he"),
-                                                                 ("ji", "yi"),
-                                                                 ("jw", "jv"),
-                                                                 ("mo", "ro"),
-                                                                 ("aam", "aas"),
-                                                                 ("adp", "dz"),
-                                                                 ("aue", "ktz"),
-                                                                 ("ayx", "nun"),
-                                                                 ("bjd", "drl"),
-                                                                 ("ccq", "rki"),
-                                                                 ("cjr", "mom"),
-                                                                 ("cka", "cmr"),
-                                                                 ("cmk", "xch"),
-                                                                 ("drh", "khk"),
-                                                                 ("drw", "prs"),
-                                                                 ("gav", "dev"),
-                                                                 ("gfx", "vaj"),
-                                                                 ("gti", "nyc"),
-                                                                 ("hrr", "jal"),
-                                                                 ("ibi", "opa"),
-                                                                 ("ilw", "gal"),
-                                                                 ("kgh", "kml"),
-                                                                 ("koj", "kwv"),
-                                                                 ("kwq", "yam"),
-                                                                 ("kxe", "tvd"),
-                                                                 ("lii", "raq"),
-                                                                 ("lmm", "rmx"),
-                                                                 ("meg", "cir"),
-                                                                 ("mst", "mry"),
-                                                                 ("mwj", "vaj"),
-                                                                 ("myt", "mry"),
-                                                                 ("nnx", "ngv"),
-                                                                 ("oun", "vaj"),
-                                                                 ("pcr", "adx"),
-                                                                 ("pmu", "phr"),
-                                                                 ("ppr", "lcq"),
-                                                                 ("puz", "pub"),
-                                                                 ("sca", "hle"),
-                                                                 ("thx", "oyb"),
-                                                                 ("tie", "ras"),
-                                                                 ("tkk", "twm"),
-                                                                 ("tlw", "weo"),
-                                                                 ("tnf", "prs"),
-                                                                 ("tsf", "taj"),
-                                                                 ("uok", "ema"),
-                                                                 ("xia", "acn"),
-                                                                 ("xsj", "suj"),
-                                                                 ("ybd", "rki"),
-                                                                 ("yma", "lrr"),
-                                                                 ("ymt", "mtm"),
-                                                                 ("yos", "zom"),
-                                                                 ("yuu", "yug")];
+const DEPRECATED_LANGUAGE: [(&str, &str); 53] = [
+    ("in", "id"),
+    ("iw", "he"),
+    ("ji", "yi"),
+    ("jw", "jv"),
+    ("mo", "ro"),
+    ("aam", "aas"),
+    ("adp", "dz"),
+    ("aue", "ktz"),
+    ("ayx", "nun"),
+    ("bjd", "drl"),
+    ("ccq", "rki"),
+    ("cjr", "mom"),
+    ("cka", "cmr"),
+    ("cmk", "xch"),
+    ("drh", "khk"),
+    ("drw", "prs"),
+    ("gav", "dev"),
+    ("gfx", "vaj"),
+    ("gti", "nyc"),
+    ("hrr", "jal"),
+    ("ibi", "opa"),
+    ("ilw", "gal"),
+    ("kgh", "kml"),
+    ("koj", "kwv"),
+    ("kwq", "yam"),
+    ("kxe", "tvd"),
+    ("lii", "raq"),
+    ("lmm", "rmx"),
+    ("meg", "cir"),
+    ("mst", "mry"),
+    ("mwj", "vaj"),
+    ("myt", "mry"),
+    ("nnx", "ngv"),
+    ("oun", "vaj"),
+    ("pcr", "adx"),
+    ("pmu", "phr"),
+    ("ppr", "lcq"),
+    ("puz", "pub"),
+    ("sca", "hle"),
+    ("thx", "oyb"),
+    ("tie", "ras"),
+    ("tkk", "twm"),
+    ("tlw", "weo"),
+    ("tnf", "prs"),
+    ("tsf", "taj"),
+    ("uok", "ema"),
+    ("xia", "acn"),
+    ("xsj", "suj"),
+    ("ybd", "rki"),
+    ("yma", "lrr"),
+    ("ymt", "mtm"),
+    ("yos", "zom"),
+    ("yuu", "yug"),
+];
 
-const DEPRECATED_REGION: [(&'static str, &'static str); 6] = [("BU", "MM"),
-                                                              ("DD", "DE"),
-                                                              ("FX", "FR"),
-                                                              ("TP", "TL"),
-                                                              ("YD", "YE"),
-                                                              ("ZR", "CD")];
+const DEPRECATED_REGION: [(&str, &str); 6] = [
+    ("BU", "MM"),
+    ("DD", "DE"),
+    ("FX", "FR"),
+    ("TP", "TL"),
+    ("YD", "YE"),
+    ("ZR", "CD"),
+];
 
-/// A language tag as described in [BCP47](http://tools.ietf.org/html/bcp47).
+/// A language tag as described in [RFC 5646](https://tools.ietf.org/html/rfc5646).
 ///
 /// Language tags are used to help identify languages, whether spoken,
 /// written, signed, or otherwise signaled, for the purpose of
 /// communication.  This includes constructed and artificial languages
 /// but excludes languages not intended primarily for human
 /// communication, such as programming languages.
-#[derive(Debug, Default, Eq, Clone)]
+#[derive(Eq, PartialEq, Debug, Clone, Hash)]
 #[cfg_attr(feature = "heap_size", derive(HeapSizeOf))]
 pub struct LanguageTag {
-    /// Language subtags are used to indicate the language, ignoring all
-    /// other aspects such as script, region or spefic invariants.
-    pub language: Option<String>,
-    /// Extended language subtags are used to identify certain specially
-    /// selected languages that, for various historical and compatibility
-    /// reasons, are closely identified with or tagged using an existing
-    /// primary language subtag.
-    pub extlangs: Vec<String>,
-    /// Script subtags are used to indicate the script or writing system
-    /// variations that distinguish the written forms of a language or its
-    /// dialects.
-    pub script: Option<String>,
-    /// Region subtags are used to indicate linguistic variations associated
-    /// with or appropriate to a specific country, territory, or region.
-    /// Typically, a region subtag is used to indicate variations such as
-    /// regional dialects or usage, or region-specific spelling conventions.
-    /// It can also be used to indicate that content is expressed in a way
-    /// that is appropriate for use throughout a region, for instance,
-    /// Spanish content tailored to be useful throughout Latin America.
-    pub region: Option<String>,
-    /// Variant subtags are used to indicate additional, well-recognized
-    /// variations that define a language or its dialects that are not
-    /// covered by other available subtags.
-    pub variants: Vec<String>,
-    /// Extensions provide a mechanism for extending language tags for use in
-    /// various applications.  They are intended to identify information that
-    /// is commonly used in association with languages or language tags but
-    /// that is not part of language identification.
-    pub extensions: BTreeMap<u8, Vec<String>>,
-    /// Private use subtags are used to indicate distinctions in language
-    /// that are important in a given context by private agreement.
-    pub privateuse: Vec<String>,
+    /// Syntax described in [RFC 5646 2.1](https://tools.ietf.org/html/rfc5646#section-2.1)
+    serialization: String,
+    language_end: usize,
+    extlang_end: usize,
+    script_end: usize,
+    region_end: usize,
+    variant_end: usize,
+    extension_end: usize,
 }
 
 impl LanguageTag {
-    /// Matches language tags. The first language acts as a language range, the second one is used
-    /// as a normal language tag. None fields in the language range are ignored. If the language
-    /// tag has more extlangs than the range these extlangs are ignored. Matches are
-    /// case-insensitive. `*` in language ranges are represented using `None` values. The language
-    /// range `*` that matches language tags is created by the default language tag:
-    /// `let wildcard: LanguageTag = Default::default();.`
+    /// Return the serialization of this language tag.
     ///
-    /// For example the range `en-GB` matches only `en-GB` and `en-Arab-GB` but not `en`.
-    /// The range `en` matches all language tags starting with `en` including `en`, `en-GB`,
-    /// `en-Arab` and `en-Arab-GB`.
-    ///
-    /// # Panics
-    /// If the language range has extensions or private use tags.
-    ///
-    /// # Examples
-    /// ```
-    /// # #[macro_use] extern crate language_tags;
-    /// # fn main() {
-    /// let range_italian = langtag!(it);
-    /// let tag_german = langtag!(de);
-    /// let tag_italian_switzerland = langtag!(it;;;CH);
-    /// assert!(!range_italian.matches(&tag_german));
-    /// assert!(range_italian.matches(&tag_italian_switzerland));
-    ///
-    /// let range_spanish_brazil = langtag!(es;;;BR);
-    /// let tag_spanish = langtag!(es);
-    /// assert!(!range_spanish_brazil.matches(&tag_spanish));
-    /// # }
-    /// ```
-    pub fn matches(&self, other: &LanguageTag) -> bool {
-        fn matches_option(a: &Option<String>, b: &Option<String>) -> bool {
-            match (a, b) {
-                (&Some(ref a), &Some(ref b)) => a.eq_ignore_ascii_case(b),
-                (&None, _) => true,
-                (_, &None) => false,
-            }
-        }
-        fn matches_vec(a: &[String], b: &[String]) -> bool {
-            a.iter().zip(b.iter()).all(|(x, y)| x.eq_ignore_ascii_case(y))
-        }
-        assert!(self.is_language_range());
-        matches_option(&self.language, &other.language) &&
-        matches_vec(&self.extlangs, &other.extlangs) &&
-        matches_option(&self.script, &other.script) &&
-        matches_option(&self.region, &other.region) &&
-        matches_vec(&self.variants, &other.variants)
+    /// This is fast since that serialization is already stored in the `LanguageTag` struct.
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        &self.serialization
     }
 
-    /// Checks if it is a language range, meaning that there are no extension and privateuse tags.
-    pub fn is_language_range(&self) -> bool {
-        self.extensions.is_empty() && self.privateuse.is_empty()
+    /// Return the serialization of this language tag.
+    ///
+    /// This consumes the `LanguageTag` and takes ownership of the `String` stored in it.
+    #[inline]
+    pub fn into_string(self) -> String {
+        self.serialization
+    }
+
+    /// Return the [primary language subtag](https://tools.ietf.org/html/rfc5646#section-2.2.1).
+    #[inline]
+    pub fn primary_language(&self) -> &str {
+        &self.serialization[..self.language_end]
+    }
+
+    /// Return the [extended language subtags](https://tools.ietf.org/html/rfc5646#section-2.2.2).
+    ///
+    /// Valid language tags have at most one extended language.
+    #[inline]
+    pub fn extended_language(&self) -> Option<&str> {
+        if self.language_end == self.extlang_end {
+            None
+        } else {
+            Some(&self.serialization[self.language_end + 1..self.extlang_end])
+        }
+    }
+
+    /// Iterate on the [extended language subtags](https://tools.ietf.org/html/rfc5646#section-2.2.2).
+    ///
+    /// Valid language tags have at most one extended language.
+    #[inline]
+    pub fn extended_language_subtags(&self) -> impl Iterator<Item = &str> {
+        match self.extended_language() {
+            Some(parts) => SubtagListIterator::new(parts),
+            None => SubtagListIterator::new(""),
+        }
+    }
+
+    /// Return the [primary language subtag](https://tools.ietf.org/html/rfc5646#section-2.2.1)
+    /// and its [extended language subtags](https://tools.ietf.org/html/rfc5646#section-2.2.2).
+    #[inline]
+    pub fn full_language(&self) -> &str {
+        &self.serialization[..self.extlang_end]
+    }
+
+    /// Return the [script subtag](https://tools.ietf.org/html/rfc5646#section-2.2.3).
+    #[inline]
+    pub fn script(&self) -> Option<&str> {
+        if self.extlang_end == self.script_end {
+            None
+        } else {
+            Some(&self.serialization[self.extlang_end + 1..self.script_end])
+        }
+    }
+
+    /// Return the [region subtag](https://tools.ietf.org/html/rfc5646#section-2.2.4).
+    #[inline]
+    pub fn region(&self) -> Option<&str> {
+        if self.script_end == self.region_end {
+            None
+        } else {
+            Some(&self.serialization[self.script_end + 1..self.region_end])
+        }
+    }
+
+    /// Return the [variant subtags](https://tools.ietf.org/html/rfc5646#section-2.2.5).
+    #[inline]
+    pub fn variant(&self) -> Option<&str> {
+        if self.region_end == self.variant_end {
+            None
+        } else {
+            Some(&self.serialization[self.region_end + 1..self.variant_end])
+        }
+    }
+
+    /// Iterate on the [variant subtags](https://tools.ietf.org/html/rfc5646#section-2.2.5).
+    #[inline]
+    pub fn variant_subtags(&self) -> impl Iterator<Item = &str> {
+        match self.variant() {
+            Some(parts) => SubtagListIterator::new(parts),
+            None => SubtagListIterator::new(""),
+        }
+    }
+
+    /// Return the [extension subtags](https://tools.ietf.org/html/rfc5646#section-2.2.6).
+    #[inline]
+    pub fn extension(&self) -> Option<&str> {
+        if self.variant_end == self.extension_end {
+            None
+        } else {
+            Some(&self.serialization[self.variant_end + 1..self.extension_end])
+        }
+    }
+
+    /// Iterate on the [extension subtags](https://tools.ietf.org/html/rfc5646#section-2.2.6).
+    #[inline]
+    pub fn extension_subtags(&self) -> impl Iterator<Item = (char, &str)> {
+        match self.extension() {
+            Some(parts) => ExtensionsIterator::new(parts),
+            None => ExtensionsIterator::new(""),
+        }
+    }
+
+    /// Return the [private use subtags](https://tools.ietf.org/html/rfc5646#section-2.2.7).
+    #[inline]
+    pub fn private_use(&self) -> Option<&str> {
+        if self.serialization.starts_with("x-") {
+            Some(&self.serialization)
+        } else if self.extension_end == self.serialization.len() {
+            None
+        } else {
+            Some(&self.serialization[self.extension_end + 1..])
+        }
+    }
+
+    /// Iterate on the [private use subtags](https://tools.ietf.org/html/rfc5646#section-2.2.7).
+    #[inline]
+    pub fn private_use_subtags(&self) -> impl Iterator<Item = &str> {
+        match self.private_use() {
+            Some(parts) => SubtagListIterator::new(&parts[2..]),
+            None => SubtagListIterator::new(""),
+        }
+    }
+
+    /// Create a `LanguageTag` from its serialization.
+    ///
+    /// This parser accepts the language tags that are "well-formed" according to
+    /// [RFC 5646](https://tools.ietf.org/html/rfc5646#section-2.2.9).
+    /// Full validation could be done with the `validate` method.
+    ///
+    ///
+    /// # Errors
+    ///
+    /// If the language tag is not "well-formed" a `ParseError` variant will be returned.
+    pub fn parse(input: &str) -> Result<Self, ParseError> {
+        //grandfathered tags
+        if let Some((tag, _)) = GRANDFATHERED
+            .iter()
+            .find(|(x, _)| x.eq_ignore_ascii_case(input))
+        {
+            // grandfathered tag
+            Ok(tag_from_primary_language(*tag))
+        } else if input.starts_with("x-") || input.starts_with("X-") {
+            // private use
+            if !is_alphanumeric_or_dash(input) {
+                Err(ParseError::ForbiddenChar)
+            } else if input.len() == 2 {
+                Err(ParseError::EmptyPrivateUse)
+            } else {
+                Ok(tag_from_primary_language(input.to_ascii_lowercase()))
+            }
+        } else {
+            parse_language_tag(input)
+        }
+    }
+
+    /// Check if the language tag is "valid" according to
+    /// [RFC 5646](https://tools.ietf.org/html/rfc5646#section-2.2.9).
+    ///
+    /// Warning: validation against IANA Language Subtag Registry is not implemented yet
+    ///
+    /// # Errors
+    ///
+    /// If the language tag is not "valid" a `ValidationError` variant will be returned.
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        // The tag is well-formed.
+        // always ok
+
+        // Either the tag is in the list of grandfathered tags or all of its
+        // primary language, extended language, script, region, and variant
+        // subtags appear in the IANA Language Subtag Registry as of the
+        // particular registry date.
+        // TODO
+
+        // There are no duplicate variant subtags.
+        if self.variant_subtags().enumerate().any(|(id1, variant1)| {
+            self.variant_subtags()
+                .enumerate()
+                .any(|(id2, variant2)| id1 != id2 && variant1 == variant2)
+        }) {
+            return Err(ValidationError::DuplicateVariant);
+        }
+
+        // There are no duplicate singleton (extension) subtags.
+        if let Some(extension) = self.extension() {
+            let mut seen_extensions = AlphanumericLowerCharSet::new();
+            if extension.split('-').any(|subtag| {
+                if subtag.len() == 1 {
+                    let extension = subtag.chars().next().unwrap();
+                    if seen_extensions.contains(extension) {
+                        true
+                    } else {
+                        seen_extensions.insert(extension);
+                        false
+                    }
+                } else {
+                    false
+                }
+            }) {
+                return Err(ValidationError::DuplicateExtension);
+            }
+        }
+
+        // There is no more than one extended language subtag.
+        // From [errata 5457](https://www.rfc-editor.org/errata/eid5457).
+        if let Some(extended_language) = self.extended_language() {
+            if extended_language.contains('-') {
+                return Err(ValidationError::MultipleExtendedLanguageSubtags);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Check if the language tag is valid according to
+    /// [RFC 5646](https://tools.ietf.org/html/rfc5646#section-2.2.9).
+    pub fn is_valid(&self) -> bool {
+        self.validate().is_ok()
     }
 
     /// Returns the canonical version of the language tag.
@@ -319,322 +408,555 @@ impl LanguageTag {
     ///
     /// The returned language tags may not be completly canonical and they are
     /// not validated.
+    ///
+    /// Warning: This function does not fully implement yet the canonization algorithm described in
+    /// [RFC 5646 4.5](https://tools.ietf.org/html/rfc5646#section-4.5)
     pub fn canonicalize(&self) -> LanguageTag {
-        if let Some(ref language) = self.language {
-            if let Some(&(_, Some(tag))) = GRANDFATHERED.iter().find(|&&(x, _)| {
-                x.eq_ignore_ascii_case(&language)
-            }) {
-                return tag.parse().expect("GRANDFATHERED list must contain only valid tags.");
-            }
-        }
-        let mut tag = self.clone();
-        if !self.extlangs.is_empty() {
-            tag.language = Some(self.extlangs[0].clone());
-            tag.extlangs = Vec::new();
-        }
-        if let Some(ref language) = self.language {
-            if let Some(&(_, l)) = DEPRECATED_LANGUAGE.iter().find(|&&(x, _)| {
-                x.eq_ignore_ascii_case(&language)
-            }) {
-                tag.language = Some(l.to_owned());
-            };
-        }
-        if let Some(ref region) = self.region {
-            if let Some(&(_, r)) = DEPRECATED_REGION.iter().find(|&&(x, _)| {
-                x.eq_ignore_ascii_case(&region)
-            }) {
-                tag.region = Some(r.to_owned());
-            };
-        }
-        tag.variants = self.variants
-                           .iter()
-                           .map(|variant| {
-                               if "heploc".eq_ignore_ascii_case(variant) {
-                                   "alalc97".to_owned()
-                               } else {
-                                   variant.clone()
-                               }
-                           })
-                           .collect();
-        tag
-    }
-}
+        let mut language = self.primary_language();
 
-impl PartialEq for LanguageTag {
-    fn eq(&self, other: &LanguageTag) -> bool {
-        fn eq_option(a: &Option<String>, b: &Option<String>) -> bool {
-            match (a, b) {
-                (&Some(ref a), &Some(ref b)) => a.eq_ignore_ascii_case(b),
-                (&None, &None) => true,
-                _ => false,
-            }
+        // Grandfathered
+        if let Some((_, Some(tag))) = GRANDFATHERED.iter().find(|(x, _)| *x == language) {
+            return tag_from_primary_language(*tag);
         }
-        fn eq_vec(a: &[String], b: &[String]) -> bool {
-            a.len() == b.len() && a.iter().zip(b.iter()).all(|(x, y)| x.eq_ignore_ascii_case(y))
-        }
-        eq_option(&self.language, &other.language) && eq_vec(&self.extlangs, &other.extlangs) &&
-        eq_option(&self.script, &other.script) &&
-        eq_option(&self.region, &other.region) && eq_vec(&self.variants, &other.variants) &&
-        BTreeSet::from_iter(&self.extensions) == BTreeSet::from_iter(&other.extensions) &&
-        self.extensions.keys().all(|a| eq_vec(&self.extensions[a], &other.extensions[a])) &&
-        eq_vec(&self.privateuse, &other.privateuse)
-    }
-}
 
-/// Handles normal tags.
-/// The parser has a position from 0 to 6. Bigger positions reepresent the ASCII codes of
-/// single character extensions
-/// language-extlangs-script-region-variant-extension-privateuse
-/// --- 0 -- -- 1 -- -- 2 - -- 3 - -- 4 -- --- x --- ---- 6 ---
-fn parse_language_tag(langtag: &mut LanguageTag, t: &str) -> Result<u8> {
-    let mut position: u8 = 0;
-    for subtag in t.split('-') {
-        if subtag.len() > 8 {
-            // All subtags have a maximum length of eight characters.
-            return Err(Error::SubtagTooLong);
+        // Extended language
+        if let Some(extended_language) = self.extended_language() {
+            language = extended_language;
         }
-        if position == 6 {
-            langtag.privateuse.push(subtag.to_owned());
-        } else if subtag.eq_ignore_ascii_case("x") {
-            position = 6;
-        } else if position == 0 {
-            // Primary language
-            if subtag.len() < 2 || !is_alphabetic(subtag) {
-                return Err(Error::InvalidLanguage);
-            }
-            langtag.language = Some(subtag.to_owned());
-            if subtag.len() < 4 {
-                // extlangs are only allowed for short language tags
-                position = 1;
+
+        //Deprecated language
+        if let Some((_, l)) = DEPRECATED_LANGUAGE.iter().find(|(x, _)| *x == language) {
+            language = l;
+        }
+
+        let mut serialization = String::with_capacity(self.serialization.len());
+        serialization.push_str(language);
+        let language_end = language.len();
+        let extlang_end = language.len();
+
+        // Script
+        if let Some(script) = self.script() {
+            serialization.push('-');
+            serialization.push_str(script);
+        }
+        let script_end = serialization.len();
+
+        // Region
+        if let Some(region) = self.region() {
+            serialization.push('-');
+            serialization.push_str(
+                if let Some(&(_, r)) = DEPRECATED_REGION.iter().find(|&&(x, _)| x == region) {
+                    r
+                } else {
+                    region
+                },
+            );
+        }
+        let region_end = serialization.len();
+
+        // Variant
+        for variant in self.variant_subtags() {
+            serialization.push('-');
+            serialization.push_str(if variant == "heploc" {
+                "alalc97"
             } else {
-                position = 2;
-            }
-        } else if position == 1 && subtag.len() == 3 && is_alphabetic(subtag) {
-            // extlangs
-            langtag.extlangs.push(subtag.to_owned());
-        } else if position <= 2 && subtag.len() == 4 && is_alphabetic(subtag) {
-            // Script
-            langtag.script = Some(subtag.to_owned());
-            position = 3;
-        } else if position <= 3 &&
-           (subtag.len() == 2 && is_alphabetic(subtag) || subtag.len() == 3 && is_numeric(subtag)) {
-            langtag.region = Some(subtag.to_owned());
-            position = 4;
-        } else if position <= 4 &&
-           (subtag.len() >= 5 && is_alphabetic(&subtag[0..1]) ||
-            subtag.len() >= 4 && is_numeric(&subtag[0..1])) {
-            // Variant
-            langtag.variants.push(subtag.to_owned());
-            position = 4;
-        } else if subtag.len() == 1 {
-            position = subtag.as_bytes()[0] as u8;
-            if langtag.extensions.contains_key(&position) {
-                return Err(Error::DuplicateExtension);
-            }
-            langtag.extensions.insert(position, Vec::new());
-        } else if position > 6 {
-            langtag.extensions
-                   .get_mut(&position)
-                   .expect("no entry found for key")
-                   .push(subtag.to_owned());
-        } else {
-            return Err(Error::InvalidSubtag);
+                variant
+            });
+        }
+        let variant_end = serialization.len();
+
+        //Extension
+        if let Some(extension) = self.extension() {
+            serialization.push('-');
+            serialization.push_str(extension);
+        }
+        let extension_end = serialization.len();
+
+        //Private use
+        if let Some(private_use) = self.private_use() {
+            serialization.push('-');
+            serialization.push_str(private_use);
+        }
+
+        LanguageTag {
+            serialization,
+            language_end,
+            extlang_end,
+            script_end,
+            region_end,
+            variant_end,
+            extension_end,
         }
     }
-    Ok(position)
+
+    /// Matches language tags. The first language acts as a language range, the second one is used
+    /// as a normal language tag. None fields in the language range are ignored. If the language
+    /// tag has more extlangs than the range these extlangs are ignored. Matches are
+    /// case-insensitive.
+    ///
+    /// For example the range `en-GB` matches only `en-GB` and `en-Arab-GB` but not `en`.
+    /// The range `en` matches all language tags starting with `en` including `en`, `en-GB`,
+    /// `en-Arab` and `en-Arab-GB`.
+    ///
+    /// # Panics
+    /// If the language range has extensions or private use tags.
+    ///
+    /// # Examples
+    /// ```rust
+    /// use language_tags::LanguageTag;
+    /// let range_italian = LanguageTag::parse("it").unwrap();
+    /// let tag_german = LanguageTag::parse("de").unwrap();
+    /// let tag_italian_switzerland = LanguageTag::parse("it-CH").unwrap();
+    /// assert!(!range_italian.matches(&tag_german));
+    /// assert!(range_italian.matches(&tag_italian_switzerland));
+    ///
+    /// let range_spanish_brazil = LanguageTag::parse("es-BR").unwrap();
+    /// let tag_spanish = LanguageTag::parse("es").unwrap();
+    /// assert!(!range_spanish_brazil.matches(&tag_spanish));
+    /// ```
+    pub fn matches(&self, other: &LanguageTag) -> bool {
+        fn matches_option(a: Option<&str>, b: Option<&str>) -> bool {
+            match (a, b) {
+                (Some(a), Some(b)) => a == b,
+                (None, _) => true,
+                (_, None) => false,
+            }
+        }
+        fn matches_iter<'a>(
+            a: impl Iterator<Item = &'a str>,
+            b: impl Iterator<Item = &'a str>,
+        ) -> bool {
+            a.zip(b).all(|(x, y)| x == y)
+        }
+        assert!(self.is_language_range());
+        self.full_language() == other.full_language()
+            && matches_option(self.script(), other.script())
+            && matches_option(self.region(), other.region())
+            && matches_iter(self.variant_subtags(), other.variant_subtags())
+    }
+
+    /// Checks if it is a language range, meaning that there are no extension and privateuse tags.
+    pub fn is_language_range(&self) -> bool {
+        self.extension().is_none() && self.private_use().is_none()
+    }
 }
 
 impl std::str::FromStr for LanguageTag {
-    type Err = Error;
-    fn from_str(s: &str) -> Result<Self> {
-        let t = s.trim();
-        if !is_alphanumeric_or_dash(t) {
-            return Err(Error::ForbiddenChar);
-        }
-        let mut langtag: LanguageTag = Default::default();
-        // Handle grandfathered tags
-        if let Some(&(tag, _)) = GRANDFATHERED.iter().find(|&&(x, _)| x.eq_ignore_ascii_case(t)) {
-            langtag.language = Some((*tag).to_owned());
-            return Ok(langtag);
-        }
-        let position = try!(parse_language_tag(&mut langtag, t));
-        if langtag.extensions.values().any(|x| x.is_empty()) {
-            // Extensions and privateuse must not be empty if present
-            return Err(Error::EmptyExtension);
-        }
-        if position == 6 && langtag.privateuse.is_empty() {
-            return Err(Error::EmptyPrivateUse);
-        }
-        if langtag.extlangs.len() > 2 {
-            // maximum 3 extlangs
-            return Err(Error::TooManyExtlangs);
-        }
-        Ok(langtag)
+    type Err = ParseError;
+
+    #[inline]
+    fn from_str(input: &str) -> Result<Self, ParseError> {
+        Self::parse(input)
     }
 }
 
 impl fmt::Display for LanguageTag {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fn cmp_ignore_ascii_case(a: &u8, b: &u8) -> Ordering {
-            fn byte_to_uppercase(x: u8) -> u8 {
-                if x > 96 {
-                    x - 32
-                } else {
-                    x
-                }
-            }
-            let x: u8 = byte_to_uppercase(*a);
-            let y: u8 = byte_to_uppercase(*b);
-            x.cmp(&y)
-        }
-        if let Some(ref x) = self.language {
-            try!(Display::fmt(&x.to_ascii_lowercase()[..], f))
-        }
-        for x in &self.extlangs {
-            try!(write!(f, "-{}", x.to_ascii_lowercase()));
-        }
-        if let Some(ref x) = self.script {
-            let y: String = x.chars()
-                             .enumerate()
-                             .map(|(i, c)| {
-                                 if i == 0 {
-                                     c.to_ascii_uppercase()
-                                 } else {
-                                     c.to_ascii_lowercase()
-                                 }
-                             })
-                             .collect();
-            try!(write!(f, "-{}", y));
-        }
-        if let Some(ref x) = self.region {
-            try!(write!(f, "-{}", x.to_ascii_uppercase()));
-        }
-        for x in &self.variants {
-            try!(write!(f, "-{}", x.to_ascii_lowercase()));
-        }
-        let mut extensions: Vec<(&u8, &Vec<String>)> = self.extensions.iter().collect();
-        extensions.sort_by(|&(a, _), &(b, _)| cmp_ignore_ascii_case(a, b));
-        for (raw_key, values) in extensions {
-            let mut key = String::new();
-            key.push(*raw_key as char);
-            try!(write!(f, "-{}", key));
-            for value in values {
-                try!(write!(f, "-{}", value));
-            }
-        }
-        if !self.privateuse.is_empty() {
-            if self.language.is_none() {
-                try!(f.write_str("x"));
-            } else {
-                try!(f.write_str("-x"));
-            }
-            for value in &self.privateuse {
-                try!(write!(f, "-{}", value));
-            }
-        }
-        Ok(())
+        f.write_str(self.as_str())
     }
 }
 
-#[macro_export]
-/// Utility for creating simple language tags.
-///
-/// The macro supports the language, exlang, script and region parts of language tags,
-/// they are separated by semicolons, omitted parts are denoted with mulitple semicolons.
-///
-/// # Examples
-/// * `it`: `langtag!(it)`
-/// * `it-LY`: `langtag!(it;;;LY)`
-/// * `it-Arab-LY`: `langtag!(it;;Arab;LY)`
-/// * `ar-afb`: `langtag!(ar;afb)`
-/// * `i-enochian`: `langtag!(i-enochian)`
-macro_rules! langtag {
-    ( $language:expr ) => {
-        $crate::LanguageTag {
-            language: Some(stringify!($language).to_owned()),
-            extlangs: Vec::new(),
-            script: None,
-            region: None,
-            variants: Vec::new(),
-            extensions: ::std::collections::BTreeMap::new(),
-            privateuse: Vec::new(),
+/// Builds a tag from its primary language
+fn tag_from_primary_language(tag: impl Into<String>) -> LanguageTag {
+    let serialization = tag.into();
+    let end = serialization.len();
+    LanguageTag {
+        serialization,
+        language_end: end,
+        extlang_end: end,
+        script_end: end,
+        region_end: end,
+        variant_end: end,
+        extension_end: end,
+    }
+}
+
+/// Handles normal tags.
+fn parse_language_tag(input: &str) -> Result<LanguageTag, ParseError> {
+    #[derive(PartialEq, Eq)]
+    enum State {
+        Start,
+        AfterLanguage,
+        AfterExtLang,
+        AfterScript,
+        AfterRegion,
+        InExtension { expected: bool },
+        InPrivateUse { expected: bool },
+    }
+
+    let mut serialization = String::with_capacity(input.len());
+
+    let mut state = State::Start;
+    let mut language_end = 0;
+    let mut extlang_end = 0;
+    let mut script_end = 0;
+    let mut region_end = 0;
+    let mut variant_end = 0;
+    let mut extension_end = 0;
+    let mut extlangs_count = 0;
+    for (subtag, end) in SubTagIterator::new(input) {
+        if subtag.is_empty() {
+            // All subtags have a maximum length of eight characters.
+            return Err(ParseError::EmptySubtag);
         }
-    };
-    ( $language:expr;;;$region:expr ) => {
-        $crate::LanguageTag {
-            language: Some(stringify!($language).to_owned()),
-            extlangs: Vec::new(),
-            script: None,
-            region: Some(stringify!($region).to_owned()),
-            variants: Vec::new(),
-            extensions: ::std::collections::BTreeMap::new(),
-            privateuse: Vec::new(),
+        if subtag.len() > 8 {
+            // All subtags have a maximum length of eight characters.
+            return Err(ParseError::SubtagTooLong);
         }
-    };
-    ( $language:expr;;$script:expr ) => {
-        $crate::LanguageTag {
-            language: Some(stringify!($language).to_owned()),
-            extlangs: Vec::new(),
-            script: Some(stringify!($script).to_owned()),
-            region: None,
-            variants: Vec::new(),
-            extensions: ::std::collections::BTreeMap::new(),
-            privateuse: Vec::new(),
+        if state == State::Start {
+            // Primary language
+            if subtag.len() < 2 || !is_alphabetic(subtag) {
+                return Err(ParseError::InvalidLanguage);
+            }
+            language_end = end;
+            serialization.extend(to_lowercase(subtag));
+            if subtag.len() < 4 {
+                // extlangs are only allowed for short language tags
+                state = State::AfterLanguage;
+            } else {
+                state = State::AfterExtLang;
+            }
+        } else if let State::InPrivateUse { .. } = state {
+            if !is_alphanumeric(subtag) {
+                return Err(ParseError::InvalidSubtag);
+            }
+            serialization.push('-');
+            serialization.extend(to_lowercase(subtag));
+            state = State::InPrivateUse { expected: false };
+        } else if subtag == "x" || subtag == "X" {
+            // We make sure extension is found
+            if let State::InExtension { expected: true } = state {
+                return Err(ParseError::EmptyExtension);
+            }
+            serialization.push('-');
+            serialization.push('x');
+            state = State::InPrivateUse { expected: true };
+        } else if subtag.len() == 1 && is_alphanumeric(subtag) {
+            // We make sure extension is found
+            if let State::InExtension { expected: true } = state {
+                return Err(ParseError::EmptyExtension);
+            }
+            let extension_tag = subtag.chars().next().unwrap().to_ascii_lowercase();
+            serialization.push('-');
+            serialization.push(extension_tag);
+            state = State::InExtension { expected: true };
+        } else if let State::InExtension { .. } = state {
+            if !is_alphanumeric(subtag) {
+                return Err(ParseError::InvalidSubtag);
+            }
+            extension_end = end;
+            serialization.push('-');
+            serialization.extend(to_lowercase(subtag));
+            state = State::InExtension { expected: false };
+        } else if state == State::AfterLanguage && subtag.len() == 3 && is_alphabetic(subtag) {
+            extlangs_count += 1;
+            if extlangs_count > 3 {
+                return Err(ParseError::TooManyExtlangs);
+            }
+            // valid extlangs
+            extlang_end = end;
+            serialization.push('-');
+            serialization.extend(to_lowercase(subtag));
+        } else if (state == State::AfterLanguage || state == State::AfterExtLang)
+            && subtag.len() == 4
+            && is_alphabetic(subtag)
+        {
+            // Script
+            script_end = end;
+            serialization.push('-');
+            serialization.extend(to_uppercase_first(subtag));
+            state = State::AfterScript;
+        } else if (state == State::AfterLanguage
+            || state == State::AfterExtLang
+            || state == State::AfterScript)
+            && (subtag.len() == 2 && is_alphabetic(subtag)
+                || subtag.len() == 3 && is_numeric(subtag))
+        {
+            // Region
+            region_end = end;
+            serialization.push('-');
+            serialization.extend(to_uppercase(subtag));
+            state = State::AfterRegion;
+        } else if (state == State::AfterLanguage
+            || state == State::AfterExtLang
+            || state == State::AfterScript
+            || state == State::AfterRegion)
+            && is_alphanumeric(subtag)
+            && (subtag.len() >= 5 && is_alphabetic(&subtag[0..1])
+                || subtag.len() >= 4 && is_numeric(&subtag[0..1]))
+        {
+            // Variant
+            variant_end = end;
+            serialization.push('-');
+            serialization.extend(to_lowercase(subtag));
+            state = State::AfterRegion;
+        } else {
+            return Err(ParseError::InvalidSubtag);
         }
-    };
-    ( $language:expr;;$script:expr;$region:expr ) => {
-        $crate::LanguageTag {
-            language: Some(stringify!($language).to_owned()),
-            extlangs: Vec::new(),
-            script: Some(stringify!($script).to_owned()),
-            region: Some(stringify!($region).to_owned()),
-            variants: Vec::new(),
-            extensions: ::std::collections::BTreeMap::new(),
-            privateuse: Vec::new(),
+    }
+
+    //We make sure we are in a correct final state
+    if let State::InExtension { expected: true } = state {
+        return Err(ParseError::EmptyExtension);
+    }
+    if let State::InPrivateUse { expected: true } = state {
+        return Err(ParseError::EmptyPrivateUse);
+    }
+
+    //We make sure we have not skipped anyone
+    if extlang_end < language_end {
+        extlang_end = language_end;
+    }
+    if script_end < extlang_end {
+        script_end = extlang_end;
+    }
+    if region_end < script_end {
+        region_end = script_end;
+    }
+    if variant_end < region_end {
+        variant_end = region_end;
+    }
+    if extension_end < variant_end {
+        extension_end = variant_end;
+    }
+
+    Ok(LanguageTag {
+        serialization,
+        language_end,
+        extlang_end,
+        script_end,
+        region_end,
+        variant_end,
+        extension_end,
+    })
+}
+
+struct SubtagListIterator<'a> {
+    split: Split<'a, char>,
+}
+
+impl<'a> SubtagListIterator<'a> {
+    fn new(input: &'a str) -> Self {
+        Self {
+            split: input.split('-'),
         }
-    };
-    ( $language:expr;$extlangs:expr) => {
-        $crate::LanguageTag {
-            language: Some(stringify!($language).to_owned()),
-            extlangs: vec![stringify!($extlangs).to_owned()],
-            script: None,
-            region: None,
-            variants: Vec::new(),
-            extensions: ::std::collections::BTreeMap::new(),
-            privateuse: Vec::new(),
+    }
+}
+
+impl<'a> Iterator for SubtagListIterator<'a> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<&'a str> {
+        let tag = self.split.next()?;
+        if tag.is_empty() {
+            None
+        } else {
+            Some(tag)
         }
-    };
-    ( $language:expr;$extlangs:expr;$script:expr) => {
-        $crate::LanguageTag {
-            language: Some(stringify!($language).to_owned()),
-            extlangs: vec![stringify!($extlangs).to_owned()],
-            script: Some(stringify!($script).to_owned()),
-            region: None,
-            variants: Vec::new(),
-            extensions: ::std::collections::BTreeMap::new(),
-            privateuse: Vec::new(),
+    }
+}
+
+struct ExtensionsIterator<'a> {
+    split: Split<'a, char>,
+    singleton: Option<char>,
+}
+
+impl<'a> ExtensionsIterator<'a> {
+    fn new(input: &'a str) -> Self {
+        Self {
+            split: input.split('-'),
+            singleton: None,
         }
-    };
-    ( $language:expr;$extlangs:expr;;$region:expr ) => {
-        $crate::LanguageTag {
-            language: Some(stringify!($language).to_owned()),
-            extlangs: vec![stringify!($extlangs).to_owned()],
-            script: None,
-            region: Some(stringify!($region).to_owned()),
-            variants: Vec::new(),
-            extensions: ::std::collections::BTreeMap::new(),
-            privateuse: Vec::new(),
+    }
+}
+
+impl<'a> Iterator for ExtensionsIterator<'a> {
+    type Item = (char, &'a str);
+
+    fn next(&mut self) -> Option<(char, &'a str)> {
+        let tag = self.split.next()?;
+        if tag.is_empty() {
+            None
+        } else if tag.len() == 1 {
+            self.singleton = tag.chars().next();
+            self.next()
+        } else if let Some(singleton) = self.singleton {
+            Some((singleton, tag))
+        } else {
+            panic!("No singleton found in extension")
         }
-    };
-    ( $language:expr;$extlangs:expr;$script:expr;$region:expr ) => {
-        $crate::LanguageTag {
-            language: Some(stringify!($language).to_owned()),
-            extlangs: vec![stringify!($extlangs).to_owned()],
-            script: Some(stringify!($script).to_owned()),
-            region: Some(stringify!($region).to_owned()),
-            variants: Vec::new(),
-            extensions: ::std::collections::BTreeMap::new(),
-            privateuse: Vec::new(),
+    }
+}
+
+struct SubTagIterator<'a> {
+    split: Split<'a, char>,
+    position: usize,
+}
+
+impl<'a> SubTagIterator<'a> {
+    fn new(input: &'a str) -> Self {
+        Self {
+            split: input.split('-'),
+            position: 0,
         }
-    };
+    }
+}
+
+impl<'a> Iterator for SubTagIterator<'a> {
+    type Item = (&'a str, usize);
+
+    fn next(&mut self) -> Option<(&'a str, usize)> {
+        let tag = self.split.next()?;
+        let tag_end = self.position + tag.len();
+        self.position = tag_end + 1;
+        Some((tag, tag_end))
+    }
+}
+
+struct AlphanumericLowerCharSet {
+    alphabetic_set: [bool; 26],
+    numeric_set: [bool; 10],
+}
+
+impl AlphanumericLowerCharSet {
+    fn new() -> Self {
+        Self {
+            alphabetic_set: [false; 26],
+            numeric_set: [false; 10],
+        }
+    }
+
+    fn contains(&mut self, c: char) -> bool {
+        if c.is_ascii_digit() {
+            self.numeric_set[char_sub(c, '0')]
+        } else if c.is_ascii_lowercase() {
+            self.alphabetic_set[char_sub(c, 'a')]
+        } else if c.is_ascii_uppercase() {
+            self.alphabetic_set[char_sub(c, 'A')]
+        } else {
+            false
+        }
+    }
+
+    fn insert(&mut self, c: char) {
+        if c.is_ascii_digit() {
+            self.numeric_set[char_sub(c, '0')] = true
+        } else if c.is_ascii_lowercase() {
+            self.alphabetic_set[char_sub(c, 'a')] = true
+        } else if c.is_ascii_uppercase() {
+            self.alphabetic_set[char_sub(c, 'A')] = true
+        }
+    }
+}
+
+fn char_sub(c1: char, c2: char) -> usize {
+    (c1 as usize) - (c2 as usize)
+}
+
+fn is_alphabetic(s: &str) -> bool {
+    s.chars().all(|x| x.is_ascii_alphabetic())
+}
+
+fn is_numeric(s: &str) -> bool {
+    s.chars().all(|x| x.is_ascii_digit())
+}
+
+fn is_alphanumeric(s: &str) -> bool {
+    s.chars().all(|x| x.is_ascii_alphanumeric())
+}
+
+fn is_alphanumeric_or_dash(s: &str) -> bool {
+    s.chars().all(|x| x.is_ascii_alphanumeric() || x == '-')
+}
+
+fn to_uppercase<'a>(s: &'a str) -> impl Iterator<Item = char> + 'a {
+    s.chars().map(|c| c.to_ascii_uppercase())
+}
+
+// Beware: panics if s.len() == 0 (should never happen in our code)
+fn to_uppercase_first<'a>(s: &'a str) -> impl Iterator<Item = char> + 'a {
+    let mut chars = s.chars();
+    once(chars.next().unwrap().to_ascii_uppercase()).chain(chars.map(|c| c.to_ascii_lowercase()))
+}
+
+fn to_lowercase<'a>(s: &'a str) -> impl Iterator<Item = char> + 'a {
+    s.chars().map(|c| c.to_ascii_lowercase())
+}
+
+/// Errors returned by `LanguageTag` parsing
+#[derive(Debug, Eq, PartialEq)]
+pub enum ParseError {
+    /// If an extension subtag is present, it must not be empty.
+    EmptyExtension,
+    /// If the `x` subtag is present, it must not be empty.
+    EmptyPrivateUse,
+    /// The langtag contains a char that is not A-Z, a-z, 0-9 or the dash.
+    ForbiddenChar,
+    /// A subtag fails to parse, it does not match any other subtags.
+    InvalidSubtag,
+    /// The given language subtag is invalid.
+    InvalidLanguage,
+    /// A subtag may be eight characters in length at maximum.
+    SubtagTooLong,
+    /// A subtag should not be empty.
+    EmptySubtag,
+    /// At maximum three extlangs are allowed, but zero to one extlangs are preferred.
+    TooManyExtlangs,
+}
+
+impl Error for ParseError {
+    fn description(&self) -> &str {
+        match self {
+            ParseError::EmptyExtension => "If an extension subtag is present, it must not be empty",
+            ParseError::EmptyPrivateUse => "If the `x` subtag is present, it must not be empty",
+            ParseError::ForbiddenChar => "The langtag contains a char not allowed",
+            ParseError::InvalidSubtag => {
+                "A subtag fails to parse, it does not match any other subtags"
+            }
+            ParseError::InvalidLanguage => "The given language subtag is invalid",
+            ParseError::SubtagTooLong => "A subtag may be eight characters in length at maximum",
+            ParseError::EmptySubtag => "A subtag should not be empty",
+            ParseError::TooManyExtlangs => "At maximum three extlangs are allowed",
+        }
+    }
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(self.description())
+    }
+}
+
+/// Errors returned by the `LanguageTag` validation
+#[derive(Debug, Eq, PartialEq)]
+pub enum ValidationError {
+    /// The same variant subtag is only allowed once in a tag.
+    DuplicateVariant,
+    /// The same extension subtag is only allowed once in a tag before the private use part.
+    DuplicateExtension,
+    /// only one extended language subtag is allowed
+    MultipleExtendedLanguageSubtags,
+}
+
+impl Error for ValidationError {
+    fn description(&self) -> &str {
+        match self {
+            ValidationError::DuplicateVariant => {
+                "The same variant subtag is only allowed once in a tag"
+            }
+            ValidationError::DuplicateExtension => {
+                "The same extension subtag is only allowed once in a tag"
+            }
+            ValidationError::MultipleExtendedLanguageSubtags => {
+                "only one extended language subtag is allowed"
+            }
+        }
+    }
+}
+
+impl fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(self.description())
+    }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,245 +1,342 @@
-#[macro_use]
 extern crate language_tags;
 
-use std::ascii::AsciiExt;
-use std::default::Default;
-use std::collections::BTreeMap;
+use std::str::FromStr;
 
-use language_tags::{Error, LanguageTag, Result};
+use language_tags::{LanguageTag, ParseError};
 
 // All tests here may be completly nonsensical.
 
+// Tests from RFC 5646 2.1.1
 #[test]
-fn test_lang_from_str() {
-    let a: LanguageTag = "de".parse().unwrap();
-    let mut b: LanguageTag = Default::default();
-    b.language = Some("de".to_owned());
-    assert_eq!(a, b);
+fn test_formatting() {
+    assert_eq!(
+        "mn-Cyrl-MN",
+        LanguageTag::parse("mn-Cyrl-MN").unwrap().as_str()
+    );
+    assert_eq!(
+        "mn-Cyrl-MN",
+        LanguageTag::parse("MN-cYRL-mn").unwrap().as_str()
+    );
+    assert_eq!(
+        "mn-Cyrl-MN",
+        LanguageTag::parse("mN-cYrL-Mn").unwrap().as_str()
+    );
+    assert_eq!(
+        "en-CA-x-ca",
+        LanguageTag::parse("en-CA-x-ca").unwrap().as_str()
+    );
+    assert_eq!(
+        "sgn-BE-FR",
+        LanguageTag::parse("sgn-BE-FR").unwrap().as_str()
+    );
+    assert_eq!(
+        "az-Latn-x-latn",
+        LanguageTag::parse("az-Latn-x-latn").unwrap().as_str()
+    );
+    assert_eq!("i-ami", LanguageTag::parse("i-ami").unwrap().as_str());
+    assert_eq!("i-ami", LanguageTag::parse("I-AMI").unwrap().as_str());
+    assert_eq!(
+        "sl-afb-Latn-005-nedis",
+        LanguageTag::parse("SL-AFB-lATN-005-nEdis")
+            .unwrap()
+            .as_str()
+    )
 }
 
+// Tests from RFC 5646 2.2.1
 #[test]
-fn test_extlang_from_str() {
-    let a: LanguageTag = "ar-afb".parse().unwrap();
-    let mut b: LanguageTag = Default::default();
-    b.language = Some("ar".to_owned());
-    b.extlangs = vec!["afb".to_owned()];
-    assert_eq!(a, b);
+fn test_primary_language() {
+    assert_eq!("fr", LanguageTag::parse("fr").unwrap().primary_language());
+    assert_eq!("de", LanguageTag::parse("de").unwrap().primary_language());
+    assert_eq!(
+        "x-fr-ch",
+        LanguageTag::parse("x-fr-CH").unwrap().primary_language()
+    );
+    assert_eq!(
+        "i-klingon",
+        LanguageTag::parse("i-klingon").unwrap().primary_language()
+    );
+    assert_eq!(
+        "i-bnn",
+        LanguageTag::parse("i-bnn").unwrap().primary_language()
+    );
+    assert_eq!(
+        "zh-hakka",
+        LanguageTag::parse("zh-hakka").unwrap().primary_language()
+    )
 }
 
+// Tests from RFC 5646 2.2.2
 #[test]
-fn test_script_from_str() {
-    let a: LanguageTag = "ar-afb-Latn".parse().unwrap();
-    let mut b: LanguageTag = Default::default();
-    b.language = Some("ar".to_owned());
-    b.extlangs = vec!["afb".to_owned()];
-    b.script = Some("latn".to_owned());
-    assert_eq!(a, b);
+fn test_extended_language() {
+    fn parts(tag: &LanguageTag) -> (&str, &str, Option<&str>, Vec<&str>) {
+        (
+            tag.full_language(),
+            tag.primary_language(),
+            tag.extended_language(),
+            tag.extended_language_subtags().collect(),
+        )
+    }
+
+    assert_eq!(("zh", "zh", None, vec![]), parts(&"zh".parse().unwrap()));
+    assert_eq!(
+        ("zh-gan", "zh", Some("gan"), vec!["gan"]),
+        parts(&"zh-gan".parse().unwrap())
+    );
+    assert_eq!(
+        ("zh-gan-foo", "zh", Some("gan-foo"), vec!["gan", "foo"]),
+        parts(&"zh-gan-foo".parse().unwrap())
+    );
+    assert_eq!(
+        ("zh-min-nan", "zh-min-nan", None, vec![]),
+        parts(&"zh-min-nan".parse().unwrap())
+    );
+    assert_eq!(
+        ("i-tsu", "i-tsu", None, vec![]),
+        parts(&"i-tsu".parse().unwrap())
+    );
+    assert_eq!(("zh", "zh", None, vec![]), parts(&"zh-CN".parse().unwrap()));
+    assert_eq!(
+        ("zh-gan", "zh", Some("gan"), vec!["gan"]),
+        parts(&"zh-gan-CN".parse().unwrap())
+    );
+    assert_eq!(
+        ("ar-afb", "ar", Some("afb"), vec!["afb"]),
+        parts(&"ar-afb".parse().unwrap())
+    );
 }
 
+// Tests from RFC 5646 2.2.3
 #[test]
-fn test_region_from_str() {
-    let mut a: LanguageTag = "ar-DE".parse().unwrap();
-    let mut b: LanguageTag = Default::default();
-    b.language = Some("ar".to_owned());
-    b.region = Some("de".to_owned());
-    assert_eq!(a, b);
+fn test_script() {
+    fn parts(tag: &LanguageTag) -> (&str, Option<&str>) {
+        (tag.primary_language(), tag.script())
+    }
 
-    a = "ar-005".parse().unwrap();
-    b = Default::default();
-    b.language = Some("ar".to_owned());
-    b.region = Some("005".to_owned());
-    assert_eq!(a, b);
-
-    a = "ar-005".parse().unwrap();
-    b = Default::default();
-    b.language = Some("ar".to_owned());
-    b.region = Some("005".to_owned());
-    assert_eq!(a, b);
+    assert_eq!(("sr", Some("Latn")), parts(&"sr-Latn".parse().unwrap()));
+    assert_eq!(("ar", Some("Latn")), parts(&"ar-afb-Latn".parse().unwrap()))
 }
 
+// Tests from RFC 5646 2.2.4
 #[test]
-fn test_variant_from_str() {
-    let a: LanguageTag = "sl-IT-nedis".parse().unwrap();
-    let mut b: LanguageTag = Default::default();
-    b.language = Some("sl".parse().unwrap());
-    b.region = Some("it".parse().unwrap());
-    b.variants = vec!["nedis".parse().unwrap()];
-    assert_eq!(a, b);
+fn test_region() {
+    fn parts(tag: &LanguageTag) -> (&str, Option<&str>, Option<&str>) {
+        (tag.primary_language(), tag.script(), tag.region())
+    }
+
+    assert_eq!(("de", None, Some("AT")), parts(&"de-AT".parse().unwrap()));
+    assert_eq!(
+        ("sr", Some("Latn"), Some("RS")),
+        parts(&"sr-Latn-RS".parse().unwrap())
+    );
+    assert_eq!(("es", None, Some("419")), parts(&"es-419".parse().unwrap()));
+    assert_eq!(("ar", None, Some("DE")), parts(&"ar-DE".parse().unwrap()));
+    assert_eq!(("ar", None, Some("005")), parts(&"ar-005".parse().unwrap()));
+}
+
+// Tests from RFC 5646 2.2.5
+#[test]
+fn test_variant() {
+    fn parts(tag: &LanguageTag) -> (&str, Option<&str>, Vec<&str>) {
+        (
+            tag.primary_language(),
+            tag.variant(),
+            tag.variant_subtags().collect(),
+        )
+    }
+
+    assert_eq!(("sl", None, vec![]), parts(&"sl".parse().unwrap()));
+    assert_eq!(
+        ("sl", Some("nedis"), vec!["nedis"]),
+        parts(&"sl-nedis".parse().unwrap())
+    );
+    assert_eq!(
+        ("de", Some("1996"), vec!["1996"]),
+        parts(&"de-CH-1996".parse().unwrap())
+    );
+    assert_eq!(
+        ("art-lojban", None, vec![]),
+        parts(&"art-lojban".parse().unwrap())
+    );
+}
+
+// Tests from RFC 5646 2.2.6
+#[test]
+fn test_extension() {
+    fn parts(tag: &LanguageTag) -> (&str, Option<&str>, Vec<(char, &str)>) {
+        (
+            tag.primary_language(),
+            tag.extension(),
+            tag.extension_subtags().collect(),
+        )
+    }
+
+    assert_eq!(("en", None, vec![]), parts(&"en".parse().unwrap()));
+    assert_eq!(
+        ("en", Some("a-bbb"), vec![('a', "bbb")]),
+        parts(&"en-a-bbb-x-a-ccc".parse().unwrap())
+    );
+    assert_eq!(
+        ("fr", Some("a-latn"), vec![('a', "latn")]),
+        parts(&"fr-a-Latn".parse().unwrap())
+    );
+    assert_eq!(
+        (
+            "en",
+            Some("r-extended-sequence"),
+            vec![('r', "extended"), ('r', "sequence")]
+        ),
+        parts(
+            &"en-Latn-GB-boont-r-extended-sequence-x-private"
+                .parse()
+                .unwrap()
+        )
+    );
+    assert_eq!(("i-tsu", None, vec![]), parts(&"i-tsu".parse().unwrap()));
+}
+
+// Tests from RFC 5646 2.2.7
+#[test]
+fn test_privateuse() {
+    fn parts(tag: &LanguageTag) -> (&str, Option<&str>, Vec<&str>) {
+        (
+            tag.primary_language(),
+            tag.private_use(),
+            tag.private_use_subtags().collect(),
+        )
+    }
+
+    assert_eq!(("en", None, vec![]), parts(&"en".parse().unwrap()));
+    assert_eq!(
+        ("en", Some("x-us"), vec!["us"]),
+        parts(&"en-x-US".parse().unwrap())
+    );
+    assert_eq!(
+        ("el", Some("x-koine"), vec!["koine"]),
+        parts(&"el-x-koine".parse().unwrap())
+    );
+    assert_eq!(
+        ("x-fr-ch", Some("x-fr-ch"), vec!["fr", "ch"]),
+        parts(&"x-fr-ch".parse().unwrap())
+    );
+    assert_eq!(
+        ("es", Some("x-foobar-at-007"), vec!["foobar", "at", "007"]),
+        parts(&"es-x-foobar-AT-007".parse().unwrap())
+    )
+}
+
+// Tests from RFC 5646 2.2.9
+#[test]
+fn test_is_valid() {
+    assert!(LanguageTag::parse("sr-Latn-RS").unwrap().is_valid());
+    assert!(!LanguageTag::parse("de-DE-1901-aaaaa-1901")
+        .unwrap()
+        .is_valid());
+    assert!(!LanguageTag::parse("en-a-bbb-a-ccc").unwrap().is_valid());
+    assert!(!LanguageTag::parse("ab-c-abc-r-toto-c-abc")
+        .unwrap()
+        .is_valid());
+    assert!(LanguageTag::parse("en-a-bbb-x-a-ccc").unwrap().is_valid());
 }
 
 #[test]
 fn test_invalid_from_str() {
-    assert_eq!("sl-07".parse::<LanguageTag>(), Err(Error::InvalidSubtag));
-}
-
-#[test]
-fn test_strange_case_from_str() {
-    // This is a perfectly valid language code
-    let a: LanguageTag = "SL-AFB-lATN-005-nEdis".parse().unwrap();
-    let b = LanguageTag {
-        language: Some("sl".to_owned()),
-        extlangs: vec!["afb".to_owned()],
-        script: Some("Latn".to_owned()),
-        region: Some("005".to_owned()),
-        variants: vec!["nedis".to_owned()],
-        extensions: BTreeMap::new(),
-        privateuse: Vec::new(),
-    };
-    assert_eq!(a, b);
+    assert_eq!(
+        "sl-07".parse::<LanguageTag>(),
+        Err(ParseError::InvalidSubtag)
+    );
 }
 
 #[test]
 fn test_fmt() {
-    let a: LanguageTag = "ar-arb-Latn-DE-nedis-foobar".parse().unwrap();
-    assert_eq!(format!("{}", a), "ar-arb-Latn-DE-nedis-foobar");
-    let b: LanguageTag = "ar-arb-latn-de-nedis-foobar".parse().unwrap();
-    assert_eq!(format!("{}", b), "ar-arb-Latn-DE-nedis-foobar");
-    let b: LanguageTag = "AR-ARB-LATN-DE-NEDIS-FOOBAR".parse().unwrap();
-    assert_eq!(format!("{}", b), "ar-arb-Latn-DE-nedis-foobar");
-    let b: LanguageTag = "xx-z-foo-a-bar-F-spam-b-eggs".parse().unwrap();
-    assert_eq!(format!("{}", b), "xx-a-bar-b-eggs-F-spam-z-foo");
-}
-
-#[test]
-fn test_match() {
-    let de_de: LanguageTag = "de-DE".parse().unwrap();
-    let de: LanguageTag = "de".parse().unwrap();
-    assert!(de.matches(&de_de));
-    assert!(!de_de.matches(&de));
-}
-
-#[test]
-fn test_match_all() {
-    let de_de: LanguageTag = "de-DE".parse().unwrap();
-    let crazy: LanguageTag = "GDJ-nHYa-bw-X-ke-rohH5GfS-LdJKsGVe".parse().unwrap();
-    let wildcard: LanguageTag = Default::default();
-    assert!(wildcard.matches(&de_de));
-    assert!(wildcard.matches(&crazy));
-}
-
-#[test]
-fn test_klingon() {
-    let a: LanguageTag = "i-klingon".parse().unwrap();
-    let mut b: LanguageTag = Default::default();
-    b.language = Some("i-klingon".to_owned());
-    assert_eq!(a, b);
-}
-
-#[test]
-fn test_private_use() {
-    let a: LanguageTag = "es-x-foobar-AT-007".parse().unwrap();
-    let mut b: LanguageTag = Default::default();
-    b.language = Some("es".to_owned());
-    b.privateuse = vec!["foobar".to_owned(), "AT".to_owned(), "007".to_owned()];
-    assert_eq!(a, b);
+    assert_eq!(
+        "ar-arb-Latn-DE-nedis-foobar",
+        LanguageTag::parse("ar-arb-Latn-DE-nedis-foobar")
+            .unwrap()
+            .to_string()
+    );
+    assert_eq!(
+        "ar-arb-Latn-DE-nedis-foobar",
+        LanguageTag::parse("ar-arb-latn-de-nedis-foobar")
+            .unwrap()
+            .to_string()
+    );
+    assert_eq!(
+        "ar-arb-Latn-DE-nedis-foobar",
+        LanguageTag::parse("AR-ARB-LATN-DE-NEDIS-FOOBAR")
+            .unwrap()
+            .to_string()
+    );
+    assert_eq!(
+        "xx-z-foo-a-bar-f-spam-b-eggs",
+        LanguageTag::parse("xx-z-foo-a-bar-F-spam-b-eggs")
+            .unwrap()
+            .to_string()
+    );
+    assert_eq!(
+        "hkgnmerm-x-e5-zf-vddjcpz-1v6",
+        LanguageTag::parse("HkgnmerM-x-e5-zf-VdDjcpz-1V6")
+            .unwrap()
+            .to_string()
+    );
+    assert_eq!(
+        "mgxqa-Ywep-8lcw-7bvt-h-dp1md-0h7-0z3ir",
+        LanguageTag::parse("MgxQa-ywEp-8lcW-7bvT-h-dP1Md-0h7-0Z3ir")
+            .unwrap()
+            .to_string()
+    );
 }
 
 #[test]
 fn test_unicode() {
-    let x: Result<LanguageTag> = "zh-x-Üńìcødê".parse();
-    assert!(x.is_err());
+    assert!(LanguageTag::parse("zh-x-Üńìcødê").is_err());
 }
 
 #[test]
-fn test_format() {
-    let x: LanguageTag = "HkgnmerM-x-e5-zf-VdDjcpz-1V6".parse().unwrap();
-    assert!(format!("{}", x).eq_ignore_ascii_case("HkgnmerM-x-e5-zf-VdDjcpz-1V6"));
-    let y: LanguageTag = "MgxQa-ywEp-8lcW-7bvT-h-dP1Md-0h7-0Z3ir".parse().unwrap();
-    assert!(format!("{}", y).eq_ignore_ascii_case("MgxQa-ywEp-8lcW-7bvT-h-dP1Md-0h7-0Z3ir"));
-}
+fn test_format() {}
 
 #[test]
 fn test_cmp() {
-    assert_eq!(langtag!(dE;;AraB;lY), langtag!(DE;;aRaB;LY));
-    assert!(langtag!(dE;;AraB;lY).matches(&langtag!(DE;;aRaB;LY)));
-    let mut extensions = BTreeMap::new();
-    extensions.insert(75 /* K */, vec!["foo".to_owned(), "bar".to_owned()]);
-    extensions.insert(112 /* p */, vec!["spam".to_owned(), "eggs".to_owned()]);
-    let langtag = LanguageTag {
-        language: Some("it".to_owned()),
-        extlangs: Vec::new(),
-        script: None,
-        region: None,
-        variants: Vec::new(),
-        extensions: extensions,
-        privateuse: Vec::new(),
-    };
-    assert_eq!(langtag, langtag);
+    assert_eq!(
+        LanguageTag::parse("dE-AraB-lY"),
+        LanguageTag::parse("DE-aRaB-LY")
+    );
+    assert_ne!(LanguageTag::parse("zh"), LanguageTag::parse("zh-Latn"));
 }
 
 #[test]
-fn test_macro() {
-    let a1 = langtag!(it);
-    let a2 = LanguageTag {
-        language: Some("it".to_owned()),
-        extlangs: Vec::new(),
-        script: None,
-        region: None,
-        variants: Vec::new(),
-        extensions: BTreeMap::new(),
-        privateuse: Vec::new(),
-    };
-    assert_eq!(a1, a2);
-    let b1 = langtag!(it;;;LY);
-    let b2 = LanguageTag {
-        language: Some("it".to_owned()),
-        extlangs: Vec::new(),
-        script: None,
-        region: Some("LY".to_owned()),
-        variants: Vec::new(),
-        extensions: BTreeMap::new(),
-        privateuse: Vec::new(),
-    };
-    assert_eq!(b1, b2);
-    let c1 = langtag!(it;;Arab;LY);
-    let c2 = LanguageTag {
-        language: Some("it".to_owned()),
-        extlangs: Vec::new(),
-        script: Some("Arab".to_owned()),
-        region: Some("LY".to_owned()),
-        variants: Vec::new(),
-        extensions: BTreeMap::new(),
-        privateuse: Vec::new(),
-    };
-    assert_eq!(c1, c2);
+fn test_canonicalize() {
+    assert_eq!(
+        "en-MM",
+        LanguageTag::parse("en-BU").unwrap().canonicalize().as_str()
+    );
+    assert_eq!(
+        "sfb",
+        LanguageTag::parse("sgn-BE-FR")
+            .unwrap()
+            .canonicalize()
+            .as_str()
+    );
+    assert_eq!(
+        "ja-Latn-alalc97",
+        LanguageTag::parse("ja-Latn-heploc")
+            .unwrap()
+            .canonicalize()
+            .as_str()
+    );
 }
 
-#[test]
-fn test_private_tag() {
-    let mut tag: LanguageTag = Default::default();
-    tag.privateuse = vec!["foo".to_owned(), "bar".to_owned()];
-    assert_eq!(format!("{}", tag), "x-foo-bar");
-}
-
-#[test]
-fn test_grandfathered_tag() {
-    let tag_irregular: LanguageTag = "i-klingon".parse().unwrap();
-    assert_eq!(tag_irregular.language.unwrap(), "i-klingon");
-    let tag_regular: LanguageTag = "zh-hakka".parse().unwrap();
-    assert_eq!(tag_regular.language.unwrap(), "zh-hakka");
-}
-
-#[test]
-fn test_eq() {
-    let mut tag1: LanguageTag = Default::default();
-    tag1.language = Some("zh".to_owned());
-    let mut tag2: LanguageTag = Default::default();
-    tag2.language = Some("zh".to_owned());
-    tag2.script = Some("Latn".to_owned());
-    assert!(tag1 != tag2);
-}
-
+// http://www.langtag.net/test-suites/well-formed-tags.txt
 #[test]
 fn test_wellformed_tags() {
-    // Source: http://www.langtag.net/test-suites/well-formed-tags.txt
     let tags = vec![
-        "fr ",
+        "fr",
         "fr-Latn",
         "fr-fra", // Extended tag
         "fr-Latn-FR",
         "fr-Latn-419",
         "fr-FR",
-        "ax-TZ", // Not in the registry, but well-formed
+        "ax-TZ",     // Not in the registry, but well-formed
         "fr-shadok", // Variant
         "fr-y-myext-myext2",
         "fra-Latn", // ISO 639 can be 3-letters
@@ -247,15 +344,15 @@ fn test_wellformed_tags() {
         "fra-FX",
         "i-klingon", // grandfathered with singleton
         "I-kLINgon", // tags are case-insensitive...
-        "no-bok", // grandfathered without singleton
-        "fr-Lat", // Extended",
+        "no-bok",    // grandfathered without singleton
+        "fr-Lat",    // Extended",
         "mn-Cyrl-MN",
         "mN-cYrL-Mn",
         "fr-Latn-CA",
         "en-US",
         "fr-Latn-CA",
         "i-enochian", // Grand fathered
-        "x-fr-CH ",
+        "x-fr-CH",
         "sr-Latn-CS",
         "es-419",
         "sl-nedis",
@@ -269,11 +366,11 @@ fn test_wellformed_tags() {
         "az-Arab-x-AZE-derbend",
         "es-Latn-CO-x-private",
         "en-US-boont",
-        "ab-x-abc-x-abc", // anything goes after x
-        "ab-x-abc-a-a", // ditto",
-        "i-default", // grandfathered",
-        "i-klingon", // grandfathered",
-        "abcd-Latn", // Language of 4 chars reserved for future use
+        "ab-x-abc-x-abc",     // anything goes after x
+        "ab-x-abc-a-a",       // ditto",
+        "i-default",          // grandfathered",
+        "i-klingon",          // grandfathered",
+        "abcd-Latn",          // Language of 4 chars reserved for future use
         "AaBbCcDd-x-y-any-x", // Language of 5-8 chars, registered
         "en",
         "de-AT",
@@ -289,26 +386,44 @@ fn test_wellformed_tags() {
         "zh-gan",
         "zh-yue-Hant-HK",
         "xr-lxs-qut", // extlangS
-        "xr-lqt-qu", // extlang + region
-        "xr-p-lze", // Extension
+        "xr-lqt-qu",  // extlang + region
+        "xr-p-lze",   // Extension
     ];
-    let failed: Vec<&str> = tags.iter()
-                                .filter(|x| x.parse::<LanguageTag>().is_err())
-                                .map(|&x| x)
-                                .collect();
-    println!("Number: { } Failed: {:?}", failed.len(), failed);
-    assert!(failed.is_empty());
+    for tag in tags {
+        let result = LanguageTag::from_str(tag);
+        assert!(
+            result.is_ok(),
+            "{} should be considered well-formed but returned error {}",
+            tag,
+            result.err().unwrap()
+        );
+    }
 }
 
 #[test]
+fn test_match() {
+    let de_latn_de: LanguageTag = "de-Latn-DE".parse().unwrap();
+    let de_de: LanguageTag = "de-DE".parse().unwrap();
+    let de: LanguageTag = "de".parse().unwrap();
+    assert!(de.matches(&de));
+    assert!(de.matches(&de_de));
+    assert!(de.matches(&de_latn_de));
+    assert!(!de_de.matches(&de));
+    assert!(de_de.matches(&de_de));
+    assert!(de_de.matches(&de_latn_de));
+    assert!(!de_latn_de.matches(&de));
+    assert!(!de_latn_de.matches(&de_de));
+    assert!(de_latn_de.matches(&de_latn_de));
+}
+
+// http://www.langtag.net/test-suites/broken-tags.txt
+#[test]
 fn test_broken_tags() {
-    // http://www.langtag.net/test-suites/broken-tags.txt
     let tags = vec![
         "f",
         "f-Latn",
         "fr-Latn-F",
         "a-value",
-        "en-a-bbb-a-ccc", // 'a' appears twice
         "tlh-a-b-foo",
         "i-notexist", // grandfathered but not registered: always invalid
         "abcdefghi-012345678",
@@ -329,252 +444,350 @@ fn test_broken_tags() {
         "ab--ab",
         "ab-abc-",
         "-ab-abc",
-        "ab-c-abc-r-toto-c-abc  # 'c' appears twice ",
         "abcd-efg",
         "aabbccddE",
     ];
-    let failed: Vec<(&str, Result<LanguageTag>)> = tags.iter()
-                                                       .map(|x| (*x, x.parse::<LanguageTag>()))
-                                                       .filter(|x| x.1.is_ok())
-                                                       .collect();
-    println!("Number: { } Failed: {:?}", failed.len(), failed);
-    assert!(failed.is_empty());
+    for tag in tags {
+        let result = LanguageTag::from_str(tag);
+        assert!(
+            result.is_err(),
+            "{} should be considered not well-formed but returned result {:?}",
+            tag,
+            result.ok().unwrap()
+        );
+    }
+}
+
+// http://www.langtag.net/test-suites/valid-tags.txt
+#[test]
+fn test_valid_tags() {
+    let tags = vec![
+        "fr",
+        "fr-Latn",
+        "fr-fra", // Extended tag
+        "fr-Latn-FR",
+        "fr-Latn-419",
+        "fr-FR",
+        "fr-y-myext-myext2",
+        "apa-Latn", // ISO 639 can be 3-letters
+        "apa",
+        "apa-CA",
+        "i-klingon", // grandfathered with singleton
+        "no-bok",    // grandfathered without singleton
+        "fr-Lat",    // Extended
+        "mn-Cyrl-MN",
+        "mN-cYrL-Mn",
+        "fr-Latn-CA",
+        "en-US",
+        "fr-Latn-CA",
+        "i-enochian", // Grand fathered
+        "x-fr-CH",
+        "sr-Latn-CS",
+        "es-419",
+        "sl-nedis",
+        "de-CH-1996",
+        "de-Latg-1996",
+        "sl-IT-nedis",
+        "en-a-bbb-x-a-ccc",
+        "de-a-value",
+        "en-x-US",
+        "az-Arab-x-AZE-derbend",
+        "es-Latn-CO-x-private",
+        "ab-x-abc-x-abc", // anything goes after x
+        "ab-x-abc-a-a",   // ditto
+        "i-default",      // grandfathered
+        "i-klingon",      // grandfathered
+        "en",
+        "de-AT",
+        "es-419",
+        "de-CH-1901",
+        "sr-Cyrl",
+        "sr-Cyrl-CS",
+        "sl-Latn-IT-rozaj",
+        "en-US-x-twain",
+        "zh-cmn",
+        "zh-cmn-Hant",
+        "zh-cmn-Hant-HK",
+        "zh-gan",
+        "zh-yue-Hant-HK",
+        "en-Latn-GB-boont-r-extended-sequence-x-private",
+        "en-US-boont",
+    ];
+    for tag in tags {
+        let result = LanguageTag::from_str(tag);
+        assert!(
+            result.is_ok(),
+            "{} should be considered well-formed but returned error {}",
+            tag,
+            result.err().unwrap()
+        );
+        let validation = result.unwrap().validate();
+        assert!(
+            validation.is_ok(),
+            "{} should be considered valid but returned error {}",
+            tag,
+            validation.err().unwrap()
+        );
+    }
+}
+
+// http://www.langtag.net/test-suites/invalid-tags.txt
+#[test]
+fn test_invalid_tags() {
+    let tags = vec![
+        "en-a-bbb-a-ccc", // 'a' appears twice, moved from broken_tags
+        "ab-c-abc-r-toto-c-abc", // 'c' appears twice ", moved from broken_tags
+                          //TODO "ax-TZ",    // Not in the registry, but well-formed
+                          //TODO "fra-Latn", // ISO 639 can be 3-letters
+                          //TODO "fra",
+                          //TODO "fra-FX",
+                          //TODO "abcd-Latn",          // Language of 4 chars reserved for future use
+                          //TODO "AaBbCcDd-x-y-any-x", // Language of 5-8 chars, registered
+                          //TODO "zh-Latm-CN",         // Typo
+                          //TODO "de-DE-1902",         // Wrong variant
+                          //TODO "fr-shadok",          // Variant
+    ];
+    for tag in tags {
+        let result = LanguageTag::from_str(tag);
+        assert!(
+            result.is_ok(),
+            "{} should be considered well-formed but returned error {}",
+            tag,
+            result.err().unwrap()
+        );
+        let validation = result.unwrap().validate();
+        assert!(validation.is_err(), "{} should be considered invalid", tag);
+    }
 }
 
 #[test]
 fn test_random_good_tags() {
     // http://unicode.org/repos/cldr/trunk/tools/java/org/unicode/cldr/util/data/langtagTest.txt
-    let tags = vec!["zszLDm-sCVS-es-x-gn762vG-83-S-mlL",
-                    "IIJdFI-cfZv",
-                    "kbAxSgJ-685",
-                    "tbutP",
-                    "hDL-595",
-                    "dUf-iUjq-0hJ4P-5YkF-WD8fk",
-                    "FZAABA-FH",
-                    "xZ-lh-4QfM5z9J-1eG4-x-K-R6VPr2z",
-                    "Fyi",
-                    "SeI-DbaG",
-                    "ch-xwFn",
-                    "OeC-GPVI",
-                    "JLzvUSi",
-                    "Fxh-hLAs",
-                    "pKHzCP-sgaO-554",
-                    "eytqeW-hfgH-uQ",
-                    "ydn-zeOP-PR",
-                    "uoWmBM-yHCf-JE",
-                    "xwYem",
-                    "zie",
-                    "Re-wjSv-Ey-i-XE-E-JjWTEB8-f-DLSH-NVzLH-AtnFGWoH-SIDE",
-                    "Ri-063-c-u6v-ZfhkToTB-C-IFfmv-XT-j-rdyYFMhK-h-pY-D5-Oh6FqBhL-hcXt-v-WdpNx71-\
-                     K-c74m4-eBTT7-JdH7Q1Z",
-                    "ji",
-                    "IM-487",
-                    "EPZ-zwcB",
-                    "GauwEcwo",
-                    "kDEP",
-                    "FwDYt-TNvo",
-                    "ottqP-KLES-x-9-i9",
-                    "fcflR-grQQ",
-                    "TvFwdu-kYhs",
-                    "WE-336",
-                    "MgxQa-ywEp-8lcW-7bvT-h-dP1Md-0h7-0Z3ir-K-Srkm-kA-7LXM-Z-whb2MiO-2mNsvbLm-W3O\
-                     -4r-U-KceIxHdI-gvMVgUBV-2uRUni-J0-7C8yTK2",
-                    "Hyr-B-evMtVoB1-mtsVZf-vQMV-gM-I-rr-kvLzg-f-lAUK-Qb36Ne-Z-7eFzOD-mv6kKf-l-miZ\
-                     7U3-k-XDGtNQG",
-                    "ybrlCpzy",
-                    "PTow-w-cAQ51-8Xd6E-cumicgt-WpkZv3NY-q-ORYPRy-v-A4jL4A-iNEqQZZ-sjKn-W-N1F-pzy\
-                     c-xP5eWz-LmsCiCcZ",
-                    "ih-DlPR-PE",
-                    "Krf-362",
-                    "WzaD",
-                    "EPaOnB-gHHn",
-                    "XYta",
-                    "NZ-RgOO-tR",
-                    "at-FE",
-                    "Tpc-693",
-                    "YFp",
-                    "gRQrQULo",
-                    "pVomZ-585",
-                    "laSu-ZcAq-338",
-                    "gCW",
-                    "PydSwHRI-TYfF",
-                    "zKmWDD",
-                    "X-bCrL5RL",
-                    "HK",
-                    "YMKGcLY",
-                    "GDJ-nHYa-bw-X-ke-rohH5GfS-LdJKsGVe",
-                    "tfOxdau-yjge-489-a-oB-I8Csb-1ESaK1v-VFNz-N-FT-ZQyn-On2-I-hu-vaW3-jIQb-vg0U-h\
-                     Ul-h-dO6KuJqB-U-tde2L-P3gHUY-vnl5c-RyO-H-gK1-zDPu-VF1oeh8W-kGzzvBbW-yuAJZ",
-                    "LwDux",
-                    "Zl-072",
-                    "Ri-Ar",
-                    "vocMSwo-cJnr-288",
-                    "kUWq-gWfQ-794",
-                    "YyzqKL-273",
-                    "Xrw-ZHwH-841-9foT-ESSZF-6OqO-0knk-991U-9p3m-b-JhiV-0Kq7Y-h-cxphLb-cDlXUBOQ-X\
-                     -4Ti-jty94yPp",
-                    "en-GB-oed",
-                    "LEuZl-so",
-                    "HyvBvFi-cCAl-X-irMQA-Pzt-H",
-                    "uDbsrAA-304",
-                    "wTS",
-                    "IWXS",
-                    "XvDqNkSn-jRDR",
-                    "gX-Ycbb-iLphEks-AQ1aJ5",
-                    "FbSBz-VLcR-VL",
-                    "JYoVQOP-Iytp",
-                    "gDSoDGD-lq-v-7aFec-ag-k-Z4-0kgNxXC-7h",
-                    "Bjvoayy-029",
-                    "qSDJd",
-                    "qpbQov",
-                    "fYIll-516",
-                    "GfgLyfWE-EHtB",
-                    "Wc-ZMtk",
-                    "cgh-VEYK",
-                    "WRZs-AaFd-yQ",
-                    "eSb-CpsZ-788",
-                    "YVwFU",
-                    "JSsHiQhr-MpjT-381",
-                    "LuhtJIQi-JKYt",
-                    "vVTvS-RHcP",
-                    "SY",
-                    "fSf-EgvQfI-ktWoG-8X5z-63PW",
-                    "NOKcy",
-                    "OjJb-550",
-                    "KB",
-                    "qzKBv-zDKk-589",
-                    "Jr",
-                    "Acw-GPXf-088",
-                    "WAFSbos",
-                    "HkgnmerM-x-e5-zf-VdDjcpz-1V6",
-                    "UAfYflJU-uXDc-YV",
-                    "x-CHsHx-VDcOUAur-FqagDTx-H-V0e74R",
-                    "uZIAZ-Xmbh-pd"];
-    let failed: Vec<(&str, Result<LanguageTag>)> = tags.iter()
-                                                       .map(|x| (*x, x.parse::<LanguageTag>()))
-                                                       .filter(|x| x.1.is_err())
-                                                       .collect();
-    println!("Number: { } Failed: {:?}", failed.len(), failed);
-    assert!(failed.is_empty());
+    let tags = vec![
+        "zszLDm-sCVS-es-x-gn762vG-83-S-mlL",
+        "IIJdFI-cfZv",
+        "kbAxSgJ-685",
+        "tbutP",
+        "hDL-595",
+        "dUf-iUjq-0hJ4P-5YkF-WD8fk",
+        "FZAABA-FH",
+        "xZ-lh-4QfM5z9J-1eG4-x-K-R6VPr2z",
+        "Fyi",
+        "SeI-DbaG",
+        "ch-xwFn",
+        "OeC-GPVI",
+        "JLzvUSi",
+        "Fxh-hLAs",
+        "pKHzCP-sgaO-554",
+        "eytqeW-hfgH-uQ",
+        "ydn-zeOP-PR",
+        "uoWmBM-yHCf-JE",
+        "xwYem",
+        "zie",
+        "Re-wjSv-Ey-i-XE-E-JjWTEB8-f-DLSH-NVzLH-AtnFGWoH-SIDE",
+        "Ri-063-c-u6v-ZfhkToTB-C-IFfmv-XT-j-rdyYFMhK-h-pY-D5-Oh6FqBhL-hcXt-v-WdpNx71-\
+         K-c74m4-eBTT7-JdH7Q1Z",
+        "ji",
+        "IM-487",
+        "EPZ-zwcB",
+        "GauwEcwo",
+        "kDEP",
+        "FwDYt-TNvo",
+        "ottqP-KLES-x-9-i9",
+        "fcflR-grQQ",
+        "TvFwdu-kYhs",
+        "WE-336",
+        "MgxQa-ywEp-8lcW-7bvT-h-dP1Md-0h7-0Z3ir-K-Srkm-kA-7LXM-Z-whb2MiO-2mNsvbLm-W3O\
+         -4r-U-KceIxHdI-gvMVgUBV-2uRUni-J0-7C8yTK2",
+        "Hyr-B-evMtVoB1-mtsVZf-vQMV-gM-I-rr-kvLzg-f-lAUK-Qb36Ne-Z-7eFzOD-mv6kKf-l-miZ\
+         7U3-k-XDGtNQG",
+        "ybrlCpzy",
+        "PTow-w-cAQ51-8Xd6E-cumicgt-WpkZv3NY-q-ORYPRy-v-A4jL4A-iNEqQZZ-sjKn-W-N1F-pzy\
+         c-xP5eWz-LmsCiCcZ",
+        "ih-DlPR-PE",
+        "Krf-362",
+        "WzaD",
+        "EPaOnB-gHHn",
+        "XYta",
+        "NZ-RgOO-tR",
+        "at-FE",
+        "Tpc-693",
+        "YFp",
+        "gRQrQULo",
+        "pVomZ-585",
+        "laSu-ZcAq-338",
+        "gCW",
+        "PydSwHRI-TYfF",
+        "zKmWDD",
+        "X-bCrL5RL",
+        "HK",
+        "YMKGcLY",
+        "GDJ-nHYa-bw-X-ke-rohH5GfS-LdJKsGVe",
+        "tfOxdau-yjge-489-a-oB-I8Csb-1ESaK1v-VFNz-N-FT-ZQyn-On2-I-hu-vaW3-jIQb-vg0U-h\
+         Ul-h-dO6KuJqB-U-tde2L-P3gHUY-vnl5c-RyO-H-gK1-zDPu-VF1oeh8W-kGzzvBbW-yuAJZ",
+        "LwDux",
+        "Zl-072",
+        "Ri-Ar",
+        "vocMSwo-cJnr-288",
+        "kUWq-gWfQ-794",
+        "YyzqKL-273",
+        "Xrw-ZHwH-841-9foT-ESSZF-6OqO-0knk-991U-9p3m-b-JhiV-0Kq7Y-h-cxphLb-cDlXUBOQ-X\
+         -4Ti-jty94yPp",
+        "en-GB-oed",
+        "LEuZl-so",
+        "HyvBvFi-cCAl-X-irMQA-Pzt-H",
+        "uDbsrAA-304",
+        "wTS",
+        "IWXS",
+        "XvDqNkSn-jRDR",
+        "gX-Ycbb-iLphEks-AQ1aJ5",
+        "FbSBz-VLcR-VL",
+        "JYoVQOP-Iytp",
+        "gDSoDGD-lq-v-7aFec-ag-k-Z4-0kgNxXC-7h",
+        "Bjvoayy-029",
+        "qSDJd",
+        "qpbQov",
+        "fYIll-516",
+        "GfgLyfWE-EHtB",
+        "Wc-ZMtk",
+        "cgh-VEYK",
+        "WRZs-AaFd-yQ",
+        "eSb-CpsZ-788",
+        "YVwFU",
+        "JSsHiQhr-MpjT-381",
+        "LuhtJIQi-JKYt",
+        "vVTvS-RHcP",
+        "SY",
+        "fSf-EgvQfI-ktWoG-8X5z-63PW",
+        "NOKcy",
+        "OjJb-550",
+        "KB",
+        "qzKBv-zDKk-589",
+        "Jr",
+        "Acw-GPXf-088",
+        "WAFSbos",
+        "HkgnmerM-x-e5-zf-VdDjcpz-1V6",
+        "UAfYflJU-uXDc-YV",
+        "x-CHsHx-VDcOUAur-FqagDTx-H-V0e74R",
+        "uZIAZ-Xmbh-pd",
+    ];
+    for tag in tags {
+        let result = LanguageTag::from_str(tag);
+        assert!(
+            result.is_ok(),
+            "{} should be considered well-formed but returned error {}",
+            tag,
+            result.err().unwrap()
+        );
+    }
 }
 
 #[test]
 fn test_random_bad_tags() {
     // http://unicode.org/repos/cldr/trunk/tools/java/org/unicode/cldr/util/data/langtagTest.txt
-    let tags = vec!["EdY-z_H791Xx6_m_kj",
-                    "qWt85_8S0-L_rbBDq0gl_m_O_zsAx_nRS",
-                    "VzyL2",
-                    "T_VFJq-L-0JWuH_u2_VW-hK-kbE",
-                    "u-t",
-                    "Q-f_ZVJXyc-doj_k-i",
-                    "JWB7gNa_K-5GB-25t_W-s-ZbGVwDu1-H3E",
-                    "b-2T-Qob_L-C9v_2CZxK86",
-                    "fQTpX_0_4Vg_L3L_g7VtALh2",
-                    "S-Z-E_J",
-                    "f6wsq-02_i-F",
-                    "9_GcUPq_G",
-                    "QjsIy_9-0-7_Dv2yPV09_D-JXWXM",
-                    "D_se-f-k",
-                    "ON47Wv1_2_W",
-                    "f-z-R_s-ha",
-                    "N3APeiw_195_Bx2-mM-pf-Z-Ip5lXWa-5r",
-                    "IRjxU-E_6kS_D_b1b_H",
-                    "NB-3-5-AyW_FQ-9hB-TrRJg3JV_3C",
-                    "yF-3a_V_FoJQAHeL_Z-Mc-u",
-                    "n_w_bbunOG_1-s-tJMT5je",
-                    "Q-AEWE_X",
-                    "57b1O_k_R6MU_sb",
-                    "hK_65J_i-o_SI-Y",
-                    "wB4B7u_5I2_I_NZPI",
-                    "J24Nb_q_d-zE",
-                    "v6-dHjJmvPS_IEb-x_A-O-i",
-                    "8_8_dl-ZgBr84u-P-E",
-                    "nIn-xD7EVhe_C",
-                    "5_N-6P_x7Of_Lo_6_YX_R",
-                    "0_46Oo0sZ-YNwiU8Wr_d-M-pg1OriV",
-                    "laiY-5",
-                    "K-8Mdd-j_ila0sSpo_aO8_J",
-                    "wNATtSL-Cp4_gPa_fD41_9z",
-                    "H_FGz5V8_n6rrcoz0_1O6d-kH-7-N",
-                    "wDOrnHU-odqJ_vWl",
-                    "gP_qO-I-jH",
-                    "h",
-                    "dJ0hX-o_csBykEhU-F",
-                    "L-Vf7_BV_eRJ5goSF_Kp",
-                    "y-oF-chnavU-H",
-                    "9FkG-8Q-8_v",
-                    "W_l_NDQqI-O_SFSAOVq",
-                    "kDG3fzXw",
-                    "t-nsSp-7-t-mUK2",
-                    "Yw-F",
-                    "1-S_3_l",
-                    "u-v_brn-Y",
-                    "4_ft_3ZPZC5lA_D",
-                    "n_dR-QodsqJnh_e",
-                    "Hwvt-bSwZwj_KL-hxg0m-3_hUG",
-                    "mQHzvcV-UL-o2O_1KhUJQo_G2_uryk3-a",
-                    "b-UTn33HF",
-                    "r-Ep-jY-aFM_N_H",
-                    "K-k-krEZ0gwD_k_ua-9dm3Oy-s_v",
-                    "XS_oS-p",
-                    "EIx_h-zf5",
-                    "p_z-0_i-omQCo3B",
-                    "1_q0N_jo_9",
-                    "0Ai-6-S",
-                    "L-LZEp_HtW",
-                    "Zj-A4JD_2A5Aj7_b-m3",
-                    "x",
-                    "p-qPuXQpp_d-jeKifB-c-7_G-X",
-                    "X94cvJ_A",
-                    "F2D25R_qk_W-w_Okf_kx",
-                    "rc-f",
-                    "D",
-                    "gD_WrDfxmF-wu-E-U4t",
-                    "Z_BN9O4_D9-D_0E_KnCwZF-84b-19",
-                    "T-8_g-u-0_E",
-                    "lXTtys9j_X_A_m-vtNiNMw_X_b-C6Nr",
-                    "V_Ps-4Y-S",
-                    "X5wGEA",
-                    "mIbHFf_ALu4_Jo1Z1",
-                    "ET-TacYx_c",
-                    "Z-Lm5cAP_ri88-d_q_fi8-x",
-                    "rTi2ah-4j_j_4AlxTs6m_8-g9zqncIf-N5",
-                    "FBaLB85_u-0NxhAy-ZU_9c",
-                    "x_j_l-5_aV95_s_tY_jp4",
-                    "PL768_D-m7jNWjfD-Nl_7qvb_bs_8_Vg",
-                    "9-yOc-gbh",
-                    "6DYxZ_SL-S_Ye",
-                    "ZCa-U-muib-6-d-f_oEh_O",
-                    "Qt-S-o8340F_f_aGax-c-jbV0gfK_p",
-                    "WE_SzOI_OGuoBDk-gDp",
-                    "cs-Y_9",
-                    "m1_uj",
-                    "Y-ob_PT",
-                    "li-B",
-                    "f-2-7-9m_f8den_J_T_d",
-                    "p-Os0dua-H_o-u",
-                    "L",
-                    "rby-w"];
-    let failed: Vec<(&str, Result<LanguageTag>)> = tags.iter()
-                                                       .map(|x| (*x, x.parse::<LanguageTag>()))
-                                                       .filter(|x| x.1.is_ok())
-                                                       .collect();
-    println!("Number: { } Failed: {:?}", failed.len(), failed);
-    assert!(failed.is_empty());
-}
-
-#[test]
-fn test_canonicalize() {
-    let langtag = langtag!(en;;;BU);
-    assert_eq!(langtag.canonicalize().to_string(), "en-MM");
-    let langtag = LanguageTag {
-        language: Some("sgn-BE-FR".to_owned()),
-        extlangs: vec![],
-        script: None,
-        region: None,
-        variants: vec![],
-        extensions: BTreeMap::new(),
-        privateuse: vec![],
-    };
-    assert_eq!(langtag.canonicalize().to_string(), "sfb");
+    let tags = vec![
+        "EdY-z_H791Xx6_m_kj",
+        "qWt85_8S0-L_rbBDq0gl_m_O_zsAx_nRS",
+        "VzyL2",
+        "T_VFJq-L-0JWuH_u2_VW-hK-kbE",
+        "u-t",
+        "Q-f_ZVJXyc-doj_k-i",
+        "JWB7gNa_K-5GB-25t_W-s-ZbGVwDu1-H3E",
+        "b-2T-Qob_L-C9v_2CZxK86",
+        "fQTpX_0_4Vg_L3L_g7VtALh2",
+        "S-Z-E_J",
+        "f6wsq-02_i-F",
+        "9_GcUPq_G",
+        "QjsIy_9-0-7_Dv2yPV09_D-JXWXM",
+        "D_se-f-k",
+        "ON47Wv1_2_W",
+        "f-z-R_s-ha",
+        "N3APeiw_195_Bx2-mM-pf-Z-Ip5lXWa-5r",
+        "IRjxU-E_6kS_D_b1b_H",
+        "NB-3-5-AyW_FQ-9hB-TrRJg3JV_3C",
+        "yF-3a_V_FoJQAHeL_Z-Mc-u",
+        "n_w_bbunOG_1-s-tJMT5je",
+        "Q-AEWE_X",
+        "57b1O_k_R6MU_sb",
+        "hK_65J_i-o_SI-Y",
+        "wB4B7u_5I2_I_NZPI",
+        "J24Nb_q_d-zE",
+        "v6-dHjJmvPS_IEb-x_A-O-i",
+        "8_8_dl-ZgBr84u-P-E",
+        "nIn-xD7EVhe_C",
+        "5_N-6P_x7Of_Lo_6_YX_R",
+        "0_46Oo0sZ-YNwiU8Wr_d-M-pg1OriV",
+        "laiY-5",
+        "K-8Mdd-j_ila0sSpo_aO8_J",
+        "wNATtSL-Cp4_gPa_fD41_9z",
+        "H_FGz5V8_n6rrcoz0_1O6d-kH-7-N",
+        "wDOrnHU-odqJ_vWl",
+        "gP_qO-I-jH",
+        "h",
+        "dJ0hX-o_csBykEhU-F",
+        "L-Vf7_BV_eRJ5goSF_Kp",
+        "y-oF-chnavU-H",
+        "9FkG-8Q-8_v",
+        "W_l_NDQqI-O_SFSAOVq",
+        "kDG3fzXw",
+        "t-nsSp-7-t-mUK2",
+        "Yw-F",
+        "1-S_3_l",
+        "u-v_brn-Y",
+        "4_ft_3ZPZC5lA_D",
+        "n_dR-QodsqJnh_e",
+        "Hwvt-bSwZwj_KL-hxg0m-3_hUG",
+        "mQHzvcV-UL-o2O_1KhUJQo_G2_uryk3-a",
+        "b-UTn33HF",
+        "r-Ep-jY-aFM_N_H",
+        "K-k-krEZ0gwD_k_ua-9dm3Oy-s_v",
+        "XS_oS-p",
+        "EIx_h-zf5",
+        "p_z-0_i-omQCo3B",
+        "1_q0N_jo_9",
+        "0Ai-6-S",
+        "L-LZEp_HtW",
+        "Zj-A4JD_2A5Aj7_b-m3",
+        "x",
+        "p-qPuXQpp_d-jeKifB-c-7_G-X",
+        "X94cvJ_A",
+        "F2D25R_qk_W-w_Okf_kx",
+        "rc-f",
+        "D",
+        "gD_WrDfxmF-wu-E-U4t",
+        "Z_BN9O4_D9-D_0E_KnCwZF-84b-19",
+        "T-8_g-u-0_E",
+        "lXTtys9j_X_A_m-vtNiNMw_X_b-C6Nr",
+        "V_Ps-4Y-S",
+        "X5wGEA",
+        "mIbHFf_ALu4_Jo1Z1",
+        "ET-TacYx_c",
+        "Z-Lm5cAP_ri88-d_q_fi8-x",
+        "rTi2ah-4j_j_4AlxTs6m_8-g9zqncIf-N5",
+        "FBaLB85_u-0NxhAy-ZU_9c",
+        "x_j_l-5_aV95_s_tY_jp4",
+        "PL768_D-m7jNWjfD-Nl_7qvb_bs_8_Vg",
+        "9-yOc-gbh",
+        "6DYxZ_SL-S_Ye",
+        "ZCa-U-muib-6-d-f_oEh_O",
+        "Qt-S-o8340F_f_aGax-c-jbV0gfK_p",
+        "WE_SzOI_OGuoBDk-gDp",
+        "cs-Y_9",
+        "m1_uj",
+        "Y-ob_PT",
+        "li-B",
+        "f-2-7-9m_f8den_J_T_d",
+        "p-Os0dua-H_o-u",
+        "L",
+        "rby-w",
+    ];
+    for tag in tags {
+        let result = LanguageTag::from_str(tag);
+        assert!(
+            result.is_err(),
+            "{} should be considered not well-formed but returned result {:?}",
+            tag,
+            result.ok().unwrap()
+        );
+    }
 }


### PR DESCRIPTION
Closes #10 

Major changes:
* direct access to `LanguageTag` struct field has been dropped.
* `Error` type have been renamed to `ParseError` to make space for other error types in the crate (e.g. `ValidationError` for tag validation).
* The parser now only check if the tag is "well-formed" according to[RFC 5646](https://tools.ietf.org/html/rfc5646#section-2.2.9). There is a new function `validate` to check if the tag is fully "valid" according to [RFC 5646](https://tools.ietf.org/html/rfc5646#section-2.2.9). The major change is that variants and extensions are not deduplicated and sorted.
* The constructor `LanguageTag::default()` has been removed. It allows to only have language tags represented by the `LanguageTag` struct and not also the `*` language range.
* The language tag parsing does case normalization. It's cheap and safe at this point (it does not require new allocation) and allows to avoid needing case_insensitive comparisons afterwards.
* I allowed myself to reformat code using `cargo fmt`.
* I have removed the macro. I may add back support for it but I'm not sure it is very useful.

Some points I am not sure about:
* `LanguageTag::private_use()` returns the "x-" prefix. It may be better to not return it.
* The canonicalisation algorithm is not conformant yet. Improvements to it could be done in a follow-up PR.

If you are afraid of so many breaking changes I could drop this pull request and create a friendly fork of this library that would be called something like `bcp47`.