### PR TITLE
Adds support of private use ranges to LanguageTag::validate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,7 +284,9 @@ impl LanguageTag {
         // subtags appear in the IANA Language Subtag Registry as of the
         // particular registry date.
         let primary_language = self.primary_language();
-        if !is_in_from_str_slice_set(&LANGUAGES, primary_language) {
+        if !between(primary_language, "qaa", "qtz")
+            && !is_in_from_str_slice_set(&LANGUAGES, primary_language)
+        {
             return Err(ValidationError::PrimaryLanguageNotInRegistry);
         }
         if let Some(extended_language) = self.extended_language() {
@@ -299,12 +301,15 @@ impl LanguageTag {
             }
         }
         if let Some(script) = self.script() {
-            if !is_in_from_str_slice_set(&SCRIPTS, script) {
+            if !between(script, "Qaaa", "Qabx") && !is_in_from_str_slice_set(&SCRIPTS, script) {
                 return Err(ValidationError::ScriptNotInRegistry);
             }
         }
         if let Some(region) = self.region() {
-            if !is_in_from_str_slice_set(&REGIONS, region) {
+            if !between(region, "QM", "QZ")
+                && !between(region, "XA", "XZ")
+                && !is_in_from_str_slice_set(&REGIONS, region)
+            {
                 return Err(ValidationError::RegionNotInRegistry);
             }
         }
@@ -1017,6 +1022,10 @@ impl fmt::Display for ValidationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(self.description())
     }
+}
+
+fn between<T: Ord>(value: T, start: T, end: T) -> bool {
+    start <= value && value <= end
 }
 
 fn is_in_str_slice_set(slice: &[&'static str], value: &str) -> bool {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -232,6 +232,12 @@ fn test_is_valid() {
         "zh-Latn-wadegile",
         "en-unifon",
         "en-a-bbb-x-a-ccc",
+        "ccd",
+        "qra",
+        "en-Qabx",
+        "en-QU",
+        "en-XD",
+        "qqq-Latn-RS",
     ];
     for valid_tag in valid_tags {
         let validation = LanguageTag::parse(valid_tag).unwrap().validate();
@@ -247,9 +253,9 @@ fn test_is_valid() {
 #[test]
 fn test_is_not_valid() {
     let invalid_tags = vec![
-        "qqq-Latn-RS",
+        "zzz-Latn-RS",
         "sr-Latq-RS",
-        "sr-Latn-XX",
+        "sr-Latn-ZY",
         "de-gan",
         "zhb-gan",
         "zh-Hans-wadegile",


### PR DESCRIPTION
They were considered invalid before
The ranges are:
* language: qaa..qtz
* script: Qaaa..Qabx
* region QM..QZ and XA..XZ