### PR TITLE
Add optional serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,12 @@ categories = ["parser-implementations"]
 [badges]
 travis-ci = { repository = "pyfisch/rust-language-tags" }
 
+[dependencies]
+serde = { version = "1.0", optional = true }
+
 [dev-dependencies]
 bencher = "0.1"
+serde_json = "1.0"
 
 [[bench]]
 name = "language_tag"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,8 @@
 //! ```
 
 mod iana_registry;
+#[cfg(feature = "serde")]
+mod serde;
 
 use crate::iana_registry::*;
 use std::error::Error;

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,36 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::LanguageTag;
+
+impl Serialize for LanguageTag {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for LanguageTag {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let input: &str = Deserialize::deserialize(deserializer)?;
+        LanguageTag::parse(input).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic() {
+        let input = "\"en-Latn-gb-boont-r-extended-sequence-x-private\"";
+        let deser: LanguageTag = serde_json::from_str(input).unwrap();
+        deser.validate().unwrap();
+        let ser = serde_json::to_string(&deser).unwrap();
+        assert!(ser.eq_ignore_ascii_case(input));
+    }
+}


### PR DESCRIPTION
With a very basic round-trip test.

This simply calls `parse` when deserializing, so it does not perform validation or canonicalization.

Fixes #22.