### PR TITLE
Fix deserializing from reader

### DIFF
--- a/src/serde.rs
+++ b/src/serde.rs
@@ -16,8 +16,8 @@ impl<'de> Deserialize<'de> for LanguageTag {
     where
         D: Deserializer<'de>,
     {
-        let input: &str = Deserialize::deserialize(deserializer)?;
-        LanguageTag::parse(input).map_err(serde::de::Error::custom)
+        let input: String = Deserialize::deserialize(deserializer)?;
+        LanguageTag::parse(&input).map_err(serde::de::Error::custom)
     }
 }
 


### PR DESCRIPTION
When trying to deserialize language tag using Serde from reader:

```rust
let file = File::open("filename.txt").unwrap();
let reader = BufReader::new(file);

let tag: LanguageTag = serde_json::from_reader(reader).unwrap();
println!("{:#}", tag);
```

Deserialization will fail because of:

```
Error("invalid type: string \"en-us\", expected a borrowed string")
```

This PR fixes the error by replacing `&str` as a deserialization result with `String` and then borrowing it for language tag parsing.